### PR TITLE
Get Travis building and passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ node_js:
   - "0.10"
 before_script:
   - npm install -g grunt-cli
+branches:
+  only:
+    - gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "0.10"
 before_script:
   - npm install -g grunt-cli
+  - grunt bower
 branches:
   only:
     - gh-pages


### PR DESCRIPTION
- Tells it to use the `gh-pages` branch.
- Runs `grunt bower` before the test scripts so it has all necessary packages.
