### PR TITLE
New @import build process

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "bower_components"
+  "directory": "src/vendor"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,7 +114,7 @@ module.exports = function(grunt) {
    * Create custom task aliases for our component build workflow.
    */
   grunt.registerTask('test', ['jshint', 'connect', 'qunit']);
-  grunt.registerTask('vendor', ['bower', 'copy:component_assets', 'copy:docs_assets', 'concat:main', 'concat:bodyScripts']);
-  grunt.registerTask('default', ['concat:main', 'concat:bodyScripts', 'less', 'autoprefixer', 'uglify', 'test', 'copy:docs', 'topdoc']);
+  grunt.registerTask('vendor', ['copy:component_assets', 'copy:docs_assets', 'concat:bodyScripts']);
+  grunt.registerTask('default', ['concat:bodyScripts', 'less', 'autoprefixer', 'uglify', 'test', 'copy:docs', 'topdoc']);
 
 };

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-expandables",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Standard expandable (show/hide) component for Capital Framework.",
   "keywords": ["capital-framework", "capital", "expandables", "jquery", "js", "less"],
   "authors": [
@@ -17,8 +17,8 @@
   "license": "https://github.com/cfpb/cf-expandables/blob/master/TERMS.md",
   "main": "src/js/cf-expandables.js",
   "dependencies": {
-    "cf-core": "latest",
-    "cf-icons": "latest",
+    "cf-core": "^1.0.0",
+    "cf-icons": "^1.0.0",
     "jquery": "~1.11.0",
     "jquery.easing": "~1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "posttest": "forever stopall -s"
   },
   "devDependencies": {
-    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.9.1",
-    "cf-grunt-config": "~0.3.1",
+    "cf-component-demo": "^1.0.0",
+    "cf-grunt-config": "^1.0.0",
     "forever": "^0.14.1",
     "glob": "~4.3.2",
     "grunt": "~0.4.4",

--- a/src/cf-expandables.less
+++ b/src/cf-expandables.less
@@ -3,6 +3,8 @@
    Expandable Styling
    ========================================================================== */
 
+@import (less) '../../cf-core/src/cf-core.less';
+@import (less) '../../cf-icons/src/cf-icons.less';
 
 /* topdoc
   name: Theme variables

--- a/test/cf-expandables.html
+++ b/test/cf-expandables.html
@@ -158,9 +158,9 @@
 
     <!-- </div> -->
 
-    <script src="../src/vendor/jquery/jquery.js"></script>
-    <script src="../src/vendor/jquery.easing/jquery.easing.js"></script>
-    <script src="../src/vendor/qunit/qunit.js"></script>
+    <script src="../src/vendor/jquery/dist/jquery.js"></script>
+    <script src="../src/vendor/jquery.easing/js/jquery.easing.js"></script>
+    <script src="../src/vendor/qunit/qunit/qunit.js"></script>
     <!-- Load local lib and tests. -->
     <script src="../src/js/cf-expandables.js"></script>
     <script src="cf-expandables.js"></script>


### PR DESCRIPTION
This implements the changes discussed in https://github.com/cfpb/capital-framework/issues/151.
## Additions
- `@import` rules to pull in dependencies.
## Removals
- Grunt bower and concat tasks
## Changes
- `.bowerrc` points to `src/vendor` (the now defunct Grunt task used to do this).
- Updated some JS paths in the test runner.
- Bumped to `1.0.0`.
## Testing
- You can't. :neutral_face: There's a chicken vs. the egg scenario here. This project's dependencies now point to the 1.x.x version of other CF components. But those versions aren't in Bower/npm yet because their PRs are still pending. This is why Travis is failing.
- The `dev` branch was thoroughly tested prior to this PR and more testing will occur afterward. There will likely be some kinks to work out after this merge but that's okay -- semver will shield current projects from any bugs.
## Review
- @Scotchester 
- @anselmbradford 
