### PR TITLE
Updated for the new heading changes in cf-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 1.0.1 - 2015-06-05
+
+### Changed
+- Moved @import rules to top of source file to make compilation cleaner.
+
+
+## 1.0.0 - 2015-06-01
+
+### Changed
+- Build process now uses @import statements instead of Grunt concatenation.
+
+### Added
+- pa11y accessibility tests running in Travis.
+
 ## 0.7.0 - 2015-01-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 1.1.0 - 2015-11-30
+
+### Changed
+- Converted `.h#()` mixins to `.heading-#()` mixins to match cf-core's current usage
+
+
 ## 1.0.1 - 2015-06-05
 
 ### Changed

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-expandables",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Standard expandable (show/hide) component for Capital Framework.",
   "keywords": ["capital-framework", "capital", "expandables", "jquery", "js", "less"],
   "authors": [

--- a/demo/static/css/main.css
+++ b/demo/static/css/main.css
@@ -765,13 +765,13 @@ input[type="radio"] {
 */
 .u-visually-hidden {
   position: absolute;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  height: 1px;
   width: 1px;
+  height: 1px;
+  border: 0;
   margin: -1px;
   padding: 0;
-  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
 }
 /* topdoc
   name: Inline block
@@ -1232,8 +1232,18 @@ input[type="radio"] {
     display: none;
   }
 }
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
 .u-show-on-mobile {
   display: none;
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
 }
 @media only all and (max-width: 37.5em) {
   .u-show-on-mobile {
@@ -1337,19 +1347,19 @@ small {
         <h1>Example heading element</h1>
         <p class="h1">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h2.
+        - Responsive heading. At small screen sizes, displays as h2.
     - name: Heading level 2
       markup: |
         <h2>Example heading element</h2>
         <p class="h2">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h3.
+        - Responsive heading. At small screen sizes, displays as h3.
     - name: Heading level 3
       markup: |
         <h3>Example heading element</h3>
         <p class="h3">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h4.
+        - Responsive heading. At small screen sizes, displays as h4.
     - name: Heading level 4
       markup: |
         <h4>Example heading element</h4>
@@ -1362,14 +1372,14 @@ small {
       markup: |
         <h6>Example heading element</h6>
         <p class="h6">A non-heading element</p>
-    - name: Subheader
+    - name: Lead paragraph
       markup: |
-        <h1 class="subheader">Example subheader that's kinda long</h1>
-        <p class="subheader">Example subheader that's kinda long</p>
-    - name: Super header
+        <p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      notes:
+        - Responsive. Displays as an h3 on large screens; displays at h4 size (but still Regular weight) on small screens.
+    - name: Display heading (aka "superheading")
       markup: |
-        <h1 class="superheader">Example super header</h1>
-        <p class="superheader">Example super header</p>
+        <h1 class="superheading">Example display heading</h1>
   tags:
     - cf-core
 */
@@ -1392,9 +1402,9 @@ h1,
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
-  margin-bottom: 0.47058824em;
+  margin-bottom: 0.44117647em;
   font-size: 2.125em;
-  line-height: 1.29411765;
+  line-height: 1.25;
 }
 h1 em,
 .h1 em,
@@ -1403,6 +1413,12 @@ h1 i,
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
 }
 .lt-ie9 h1 em,
 .lt-ie9 .h1 em,
@@ -1424,15 +1440,159 @@ h1 b,
 .lt-ie9 .h1 b {
   font-weight: normal !important;
 }
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+p + h1,
+p + .h1,
+ul + h1,
+ul + .h1,
+ol + h1,
+ol + .h1,
+dl + h1,
+dl + .h1,
+figure + h1,
+figure + .h1,
+img + h1,
+img + .h1,
+table + h1,
+table + .h1,
+blockquote + h1,
+blockquote + .h1 {
+  margin-top: 1.76470588em;
+}
 @media only all and (max-width: 37.5em) {
   h1,
   .h1 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
-    margin-bottom: 0.73076923em;
+    margin-bottom: 0.57692308em;
     font-size: 1.625em;
-    line-height: 1.26923077;
+    line-height: 1.25;
   }
   h1 em,
   .h1 em,
@@ -1441,6 +1601,12 @@ h1 b,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
   }
   .lt-ie9 h1 em,
   .lt-ie9 .h1 em,
@@ -1462,15 +1628,392 @@ h1 b,
   .lt-ie9 .h1 b {
     font-weight: normal !important;
   }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
 }
 h2,
 .h2 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
-  margin-bottom: 0.73076923em;
+  margin-bottom: 0.57692308em;
   font-size: 1.625em;
-  line-height: 1.26923077;
+  line-height: 1.25;
 }
 h2 em,
 .h2 em,
@@ -1479,6 +2022,12 @@ h2 i,
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
 }
 .lt-ie9 h2 em,
 .lt-ie9 .h2 em,
@@ -1500,15 +2049,181 @@ h2 b,
 .lt-ie9 .h2 b {
   font-weight: normal !important;
 }
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+p + h2,
+p + .h2,
+ul + h2,
+ul + .h2,
+ol + h2,
+ol + .h2,
+dl + h2,
+dl + .h2,
+figure + h2,
+figure + .h2,
+img + h2,
+img + .h2,
+table + h2,
+table + .h2,
+blockquote + h2,
+blockquote + .h2 {
+  margin-top: 1.73076923em;
+}
+h1 + h2,
+h1 + .h2,
+.h1 + h2,
+.h1 + .h2,
+h3 + h2,
+h3 + .h2,
+.h3 + h2,
+.h3 + .h2,
+h4 + h2,
+h4 + .h2,
+.h4 + h2,
+.h4 + .h2,
+h5 + h2,
+h5 + .h2,
+.h5 + h2,
+.h5 + .h2,
+h6 + h2,
+h6 + .h2,
+.h6 + h2,
+.h6 + .h2 {
+  margin-top: 1.15384615em;
+}
 @media only all and (max-width: 37.5em) {
   h2,
   .h2 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
-    margin-bottom: 0.95454545em;
+    margin-bottom: 0.68181818em;
     font-size: 1.375em;
-    line-height: 1.27272727;
+    line-height: 1.25;
   }
   h2 em,
   .h2 em,
@@ -1517,6 +2232,12 @@ h2 b,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
   }
   .lt-ie9 h2 em,
   .lt-ie9 .h2 em,
@@ -1538,15 +2259,348 @@ h2 b,
   .lt-ie9 .h2 b {
     font-weight: normal !important;
   }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
 }
 h3,
 .h3 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
-  margin-bottom: 0.95454545em;
+  margin-bottom: 0.68181818em;
   font-size: 1.375em;
-  line-height: 1.27272727;
+  line-height: 1.25;
 }
 h3 em,
 .h3 em,
@@ -1555,6 +2609,12 @@ h3 i,
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
 }
 .lt-ie9 h3 em,
 .lt-ie9 .h3 em,
@@ -1576,15 +2636,218 @@ h3 b,
 .lt-ie9 .h3 b {
   font-weight: normal !important;
 }
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+p + h3,
+p + .h3,
+ul + h3,
+ul + .h3,
+ol + h3,
+ol + .h3,
+dl + h3,
+dl + .h3,
+figure + h3,
+figure + .h3,
+img + h3,
+img + .h3,
+table + h3,
+table + .h3,
+blockquote + h3,
+blockquote + .h3,
+h1 + h3,
+h1 + .h3,
+.h1 + h3,
+.h1 + .h3,
+h2 + h3,
+h2 + .h3,
+.h2 + h3,
+.h2 + .h3,
+h4 + h3,
+h4 + .h3,
+.h4 + h3,
+.h4 + .h3,
+h5 + h3,
+h5 + .h3,
+.h5 + h3,
+.h5 + .h3,
+h6 + h3,
+h6 + .h3,
+.h6 + h3,
+.h6 + .h3 {
+  margin-top: 1.36363636em;
+}
 @media only all and (max-width: 37.5em) {
   h3,
   .h3 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: 500;
-    margin-bottom: 1.16666667em;
+    margin-bottom: 0.83333333em;
     font-size: 1.125em;
-    line-height: 1.22222222;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
   }
   .lt-ie9 h3,
   .lt-ie9 .h3 {
@@ -1596,96 +2859,418 @@ h4,
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: 500;
-  margin-bottom: 1.16666667em;
+  margin-bottom: 0.83333333em;
   font-size: 1.125em;
-  line-height: 1.22222222;
+  line-height: 1.25;
 }
 .lt-ie9 h4,
 .lt-ie9 .h4 {
   font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+p + h4,
+p + .h4,
+ul + h4,
+ul + .h4,
+ol + h4,
+ol + .h4,
+dl + h4,
+dl + .h4,
+figure + h4,
+figure + .h4,
+img + h4,
+img + .h4,
+table + h4,
+table + .h4,
+blockquote + h4,
+blockquote + .h4,
+h1 + h4,
+h1 + .h4,
+.h1 + h4,
+.h1 + .h4,
+h2 + h4,
+h2 + .h4,
+.h2 + h4,
+.h2 + .h4,
+h3 + h4,
+h3 + .h4,
+.h3 + h4,
+.h3 + .h4,
+h5 + h4,
+h5 + .h4,
+.h5 + h4,
+.h5 + .h4,
+h6 + h4,
+h6 + .h4,
+.h6 + h4,
+.h6 + .h4 {
+  margin-top: 1.66666667em;
 }
 h5,
 .h5 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-bottom: 0.35714286em;
+  margin-bottom: 1.07142857em;
   font-size: 0.875em;
-  line-height: 1.57142857;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 .lt-ie9 h5,
 .lt-ie9 .h5 {
   font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+p + h5,
+p + .h5,
+ul + h5,
+ul + .h5,
+ol + h5,
+ol + .h5,
+dl + h5,
+dl + .h5,
+figure + h5,
+figure + .h5,
+img + h5,
+img + .h5,
+table + h5,
+table + .h5,
+blockquote + h5,
+blockquote + .h5,
+h1 + h5,
+h1 + .h5,
+.h1 + h5,
+.h1 + .h5,
+h2 + h5,
+h2 + .h5,
+.h2 + h5,
+.h2 + .h5,
+h3 + h5,
+h3 + .h5,
+.h3 + h5,
+.h3 + .h5,
+h4 + h5,
+h4 + .h5,
+.h4 + h5,
+.h4 + .h5,
+h6 + h5,
+h6 + .h5,
+.h6 + h5,
+.h6 + .h5 {
+  margin-top: 2.14285714em;
 }
 h6,
 .h6 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-bottom: 0.41666667em;
+  margin-bottom: 1.25em;
   font-size: 0.75em;
-  line-height: 1.83333333;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 .lt-ie9 h6,
 .lt-ie9 .h6 {
   font-weight: normal !important;
 }
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+p + h6,
+p + .h6,
+ul + h6,
+ul + .h6,
+ol + h6,
+ol + .h6,
+dl + h6,
+dl + .h6,
+figure + h6,
+figure + .h6,
+img + h6,
+img + .h6,
+table + h6,
+table + .h6,
+blockquote + h6,
+blockquote + .h6,
+h1 + h6,
+h1 + .h6,
+.h1 + h6,
+.h1 + .h6,
+h2 + h6,
+h2 + .h6,
+.h2 + h6,
+.h2 + .h6,
+h3 + h6,
+h3 + .h6,
+.h3 + h6,
+.h3 + .h6,
+h4 + h6,
+h4 + .h6,
+.h4 + h6,
+.h4 + .h6,
+h5 + h6,
+h5 + .h6,
+.h5 + h6,
+.h5 + .h6 {
+  margin-top: 2.5em;
+}
+.lead-paragraph,
+.subheader,
 .subheader {
-  font-weight: 500;
-  margin-bottom: 1.16666667em;
-  font-size: 1.125em;
-  line-height: 1.22222222;
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+  margin-top: 1.36363636em;
+  margin-bottom: 0.83333333em;
 }
-.lt-ie9 .subheader {
-  font-weight: normal !important;
-}
-.subheader em,
-.subheader i {
+.lead-paragraph em,
+.lead-paragraph i {
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
 }
-.lt-ie9 .subheader em,
-.lt-ie9 .subheader i {
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
   font-style: normal !important;
 }
-.subheader strong,
-.subheader b {
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
 }
-.lt-ie9 .subheader strong,
-.lt-ie9 .subheader b {
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
   font-weight: normal !important;
 }
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+.superheading,
+.superheader,
 .superheader {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
-  font-weight: bold;
-  margin-bottom: 0.1875em;
+  font-weight: normal;
+  margin-bottom: 0.41666667em;
   font-size: 3em;
   line-height: 1.25;
 }
-.lt-ie9 .superheader {
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
   font-weight: normal !important;
 }
 /* topdoc
-  name: Margins
+  name: Body copy element vertical margins
   family: cf-core
   patterns:
     - name: Consistent vertical margins
       notes:
-        - "Assumes that the font size of each of these items remains the default."
+        - Applies 15px bottom margin to all p, ul, ol, dl, figure, table, and blockquote elements.
+        - Applies -5px top margin to lists following paragraphs to reduce margin between them to 10px.
+        - Applies 8px bottom margin to list items that are not within a nav element.
+        - Assumes that the font size of each of these items remains the default.
       markup: |
         <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
         <p>Paragraph margin example</p>
   tags:
     - cf-core
@@ -1694,10 +3279,21 @@ p,
 ul,
 ol,
 dl,
+figure,
 table,
-figure {
+blockquote {
   margin-top: 0;
-  margin-bottom: 1.25em;
+  margin-bottom: 0.9375em;
+}
+p + ul,
+p + ol {
+  margin-top: -0.3125em;
+}
+:not(nav) li {
+  margin-bottom: 0.5em;
+}
+.lt-ie9 nav li {
+  margin-bottom: 0;
 }
 /* topdoc
   name: Default link
@@ -1831,16 +3427,32 @@ nav a {
   patterns:
     - name: Unordered list
       markup: |
+        <p>Paragraph example for visual reference</p>
         <ul>
-            <li>List item</li>
-            <li>List item</li>
-            <li>List item</li>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
         </ul>
+    - name: Ordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ol>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ol>
   tags:
     - cf-core
 */
 ul {
+  padding-left: 2em;
   list-style: square;
+}
+ol {
+  padding-left: 1.9375em;
+}
+ol > li {
+  padding-left: 0.0625em;
 }
 /* topdoc
   name: Tables
@@ -1892,11 +3504,47 @@ table i {
 .lt-ie9 table i {
   font-style: normal !important;
 }
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
 table strong,
 table b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
 }
 .lt-ie9 table strong,
 .lt-ie9 table b {
@@ -1913,15 +3561,119 @@ thead td {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-bottom: 0.35714286em;
+  margin-bottom: 1.07142857em;
   font-size: 0.875em;
-  line-height: 1.57142857;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 .lt-ie9 thead th,
 .lt-ie9 thead td {
   font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
 }
 thead,
 tbody tr {
@@ -1932,6 +3684,9 @@ th {
   font-style: normal;
   font-weight: bold;
   text-align: left;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
 }
 .lt-ie9 th {
   font-weight: normal !important;
@@ -1951,11 +3706,47 @@ tbody th i {
 .lt-ie9 tbody th i {
   font-style: normal !important;
 }
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
 tbody th strong,
 tbody th b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
 }
 .lt-ie9 tbody th strong,
 .lt-ie9 tbody th b {
@@ -1987,11 +3778,19 @@ tbody th b {
     - cf-core
 */
 blockquote {
-  margin: 1.25em;
+  margin-right: 0.9375em;
+  margin-left: 0.9375em;
 }
 @media only all and (min-width: 37.5625em) {
   blockquote {
-    margin: 1.75em 2.5em;
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
   }
 }
 /* topdoc
@@ -2033,11 +3832,3537 @@ label i {
 .lt-ie9 label i {
   font-style: normal !important;
 }
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
 label strong,
 label b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label input[type="radio"],
+label input[type="checkbox"] {
+  margin-right: 0.375em;
+}
+/* topdoc
+    name: Form elements
+    family: cf-core
+    notes:
+      - "The .focus class is only included for documentation demos and should
+         not be used in production."
+      - "Visit https://github.com/cfpb/cf-forms for advanced form field patterns."
+    patterns:
+    - name: type="text"
+      markup: |
+        <input type="text" value="Lorem ipsum">
+        <input class="focus" type="text" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="text" value="">
+    - name: type="search"
+      markup: |
+        <input type="search" value="Lorem ipsum">
+        <input class="focus" type="search" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="search" value="">
+    - name: type="email"
+      markup: |
+        <input type="email" value="Lorem ipsum">
+        <input class="focus" type="email" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="email" value="">
+    - name: type="url"
+      markup: |
+        <input type="url" value="Lorem ipsum">
+        <input class="focus" type="url" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="url" value="">
+    - name: type="tel"
+      markup: |
+        <input type="tel" value="Lorem ipsum">
+        <input class="focus" type="tel" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="tel" value="">
+    - name: type="number"
+      markup: |
+        <input type="number" value="1000">
+        <input class="focus" type="number" value="1000">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="number" value="">
+    - name: textarea
+      markup: |
+        <textarea>Lorem ipsum</textarea>
+        <textarea class="focus">Lorem ipsum</textarea>
+    - name: multi-select
+      markup: |
+        <select multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+        <select class="focus" multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+    tags:
+    - cf-core
+*/
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="number"],
+textarea,
+select[multiple] {
+  display: inline-block;
+  margin: 0;
+  padding: 0.375em;
+  font-family: Arial, sans-serif;
+  font-size: 1em;
+  background: #ffffff;
+  border: 1px solid #5b616b;
+  border-radius: 0;
+  vertical-align: top;
+  -webkit-appearance: none;
+  -webkit-user-modify: read-write-plaintext-only;
+}
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+input[type="text"]:focus,
+input[type="text"].focus,
+input[type="search"]:focus,
+input[type="search"].focus,
+input[type="email"]:focus,
+input[type="email"].focus,
+input[type="url"]:focus,
+input[type="url"].focus,
+input[type="tel"]:focus,
+input[type="tel"].focus,
+input[type="number"]:focus,
+input[type="number"].focus,
+textarea:focus,
+textarea.focus,
+select[multiple]:focus,
+select[multiple].focus {
+  border: 1px solid #3e94cf;
+  outline: 1px solid #3e94cf;
+  outline-offset: 0;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+::-webkit-input-placeholder {
+  color: grayscale(#c7336e);
+}
+::-moz-placeholder {
+  color: grayscale(#c7336e);
+}
+:-ms-input-placeholder {
+  color: grayscale(#c7336e);
+}
+/* topdoc
+  name: Images
+  family: cf-core
+  patterns:
+    - name: max-width
+      markup: |
+            <img src="http://placekitten.com/800/40" alt="">
+      notes:
+        - "Gives all images a default max-width of 100% of their container."
+  tags:
+    - cf-core
+*/
+img {
+  max-width: 100%;
+}
+/* topdoc
+  name: Figure
+  family: cf-core
+  patterns:
+    - name: figure
+      markup: |
+        <figure>
+            <img src="http://placekitten.com/340/320">
+        </figure>
+    - name: figure.figure__bordered
+      markup: |
+        <figure class="figure__bordered">
+            <img src="http://placekitten.com/340/320">
+        </figure>
+  tags:
+    - cf-core
+*/
+figure {
+  margin-left: 0;
+  margin-right: 0;
+}
+figure img {
+  vertical-align: middle;
+}
+.figure__bordered img {
+  border: 1px solid #d6d7d9;
+}
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Core Less file
+   ========================================================================== */
+/* ==========================================================================
+   Capital Framework
+   Less variables
+   ========================================================================== */
+/* topdoc
+  name: Theme variables
+  family: cf-core
+  notes:
+    - "The following color and sizing variables are exposed, allowing you to
+       easily override them before compiling."
+  patterns:
+    - name: Sizing
+      codenotes:
+        - |
+          @base-font-size-px
+          @base-line-height-px
+          @base-line-height
+          @bp-xs-max
+          @bp-sm-min
+          @bp-sm-max
+          @bp-med-min
+          @bp-med-max
+          @bp-lg-min
+          @bp-lg-max
+          @bp-xl-min
+    - name: Colors
+      codenotes:
+        - |
+          @text
+          @link-text
+          @link-underline
+          @link-text-visited
+          @link-underline-visited
+          @link-text-hover
+          @link-underline-hover
+          @link-text-active
+          @link-underline-active
+          @table-border
+          @thead-text
+          @thead-bg
+          @td-bg
+          @td-bg-alt
+          @input-bg
+          @input-border
+          @input-border-focus
+          @input-placeholder
+          @figure__bordered
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Media queries
+   ========================================================================== */
+/* topdoc
+  name: Media query mixins
+  family: cf-core
+  notes:
+    - "These mixins allow us to write consistent media queries using pixel
+      values, which are easier to remember. The mixins handle converting the
+      pixels into em's."
+  patterns:
+    - name: "min-width/max-width media queries"
+      codenotes:
+        - ".respond-to-min(@bp, @rules)"
+        - ".respond-to-max(@bp, @rules)"
+      notes:
+        - "@bp: the breakpoint size in pixels. It will get converted into em's."
+        - "@rules: a CSS or Less ruleset. Note that it can contain the full set
+          of Less features."
+    - name: "min-width/max-width media query usage"
+      codenotes:
+        - |
+            .respond-to-min(768px, {
+                .title {
+                    font-size: 2em;
+                }
+            });
+
+            Compiles to:
+
+            @media only all and (min-width: 48em) {
+                .title {
+                    font-size: 2em;
+                }
+            }
+    - name: "min-width/max-width media query range"
+      codenotes:
+        - ".respond-to-range(@bp1, @bp2, @rules)"
+      notes:
+        - "@bp1: the min-width breakpoint size in pixels.
+          It will get converted into em's."
+        - "@bp2: the max-width breakpoint size in pixels.
+          It will get converted into em's."
+        - "@rules: a CSS or Less ruleset. Note that it can contain the full set
+          of Less features."
+    - name: "min-width/max-width media query range usage"
+      codenotes:
+        - |
+            .respond-to-range(320px, 768px, {
+                .title {
+                    font-size: 2em;
+                }
+            });
+
+            Compiles to:
+
+            @media only all and (min-width: 20em) and (max-width: 48em) {
+                .title {
+                    font-size: 2em;
+                }
+            }
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Utilities
+   ========================================================================== */
+/* topdoc
+  name: JS-only
+  family: cf-core
+  patterns:
+    - name: Setup
+      codenotes:
+        - <html class="no-js">
+        - |
+            <script>
+                // Confirm availability of JS and remove no-js class from html
+                var docElement = document.documentElement;
+                docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
+            </script>
+      notes:
+        - "First add the .no-js class to the HTML element."
+        - "Then add the script to your HEAD which removes the .no-js class when
+           JS is available."
+    - name: Utility class
+      codenotes:
+        - .u-js-only;
+      notes:
+        - "Hide stuff when JavaScript isn't available. Depends on having a small
+           script in the HEAD of your HTML document that removes a .no-js class."
+  tags:
+    - cf-core
+*/
+.no-js .u-js-only {
+  display: none !important;
+}
+/* topdoc
+  name: Clearfix
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <div class="u-clearfix">
+            <div style="float:left; width:100%; height:60px; background:black;"></div>
+        </div>
+      codenotes:
+        - .u-clearfix;
+      notes:
+        - "Use this class to clear floats. For example, without .u-clearfix the
+           black box would spill into the markup section."
+        - "More information: http://css-tricks.com/snippets/css/clear-fix/"
+  tags:
+    - cf-core
+*/
+.u-clearfix:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.lt-ie8 .u-clearfix {
+  zoom: 1;
+}
+/* topdoc
+  name: Visually hidden
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <h1>
+            <a href="#">
+                <span class="cf-icon cf-icon-twitter-square"></span>
+                <span class="u-visually-hidden">Share on Twitter</span>
+            </a>
+        </h1>
+      codenotes:
+        - .u-visually-hidden;
+      notes:
+        - "Use this class to hide something from view while keeping it
+          accessible to screen readers."
+  tags:
+    - cf-core
+*/
+.u-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+/* topdoc
+  name: Inline block
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - .u-inline-block;
+      notes:
+        - "Also adds a .lt-ie8 class to hack inline-block for IE 7 and below."
+  tags:
+    - cf-core
+*/
+.u-inline-block {
+  display: inline-block;
+}
+.lt-ie8 .u-inline-block {
+  display: inline;
+}
+/* topdoc
+  name: Floating right
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - .u-right;
+      notes:
+        - "IE7 float: right drop bug fixes:"
+        - "1. If the float: right follows an element in the html structure that
+          should be to its left (and not above it), then that preceding
+          element(s) must be float: left.
+          http://stackoverflow.com/questions/10981767/clean-css-fix-of-ie7s-float-right-drop-bug#answer-11437688"
+        - "2. Simply change the markup order so that the element floating right
+          comes before the element to its left."
+  tags:
+    - cf-core
+*/
+.u-right {
+  float: right;
+}
+/* topdoc
+  name: Break word
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <div style="width: 100px;">
+            This link should break:
+            <br>
+            <a class="u-break-word" href="#">
+                something@something.com
+            </a>
+            <br>
+            <br>
+            This link should not:
+            <br>
+            <a href="#">
+                something@something.com
+            </a>
+        </div>
+      codenotes:
+        - .u-break-word
+      notes:
+        - "Use this on elements where you need the words to break when confined
+           to small containers."
+        - "This only works in IE8 when the element with the .u-break-word class
+           has layout. See <http://stackoverflow.com/questions/3997223/word-wrapbreak-word-not-working-in-ie8>
+           for more information."
+  tags:
+    - cf-core
+*/
+.u-break-word {
+  word-break: break-all;
+}
+/* topdoc
+  name: Align with button
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - ".u-align-with-btn(@font-size: @base-font-size-px);"
+      notes:
+        - "Adds top padding (among other things) to help alignment with buttons."
+        - "If you pass no arguments then the padding will be calculated using
+          @base-font-size-px."
+        - "Pass one argument to use a custom font size to calculate the top
+          padding."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Flexible proportional containers
+  family: cf-core
+  notes:
+    - "Utilizes intrinsic ratios to create a flexible container that retains its
+      aspect ratio. When image tags scale they retain their aspect ratio, but if
+      you need a flexible video you will need to use this mixin."
+    - "You can read more about intrinsic rations here:
+      http://alistapart.com/article/creating-intrinsic-ratios-for-video"
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="u-flexible-container">
+            <video
+              class="u-flexible-container_inner"
+              style="background:#75787B;"
+              controls>
+            </video>
+        </div>
+      notes:
+        - "Defaults to a 16:19 ratio."
+        - "Original mixin credit: https://gist.github.com/craigmdennis/6655047"
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container
+            .u-flexible-container_inner
+    - name: Background image examples
+      markup: |
+        <div class="u-flexible-container"
+             style="
+               background-image:url(http://placekitten.com/700/394);
+               background-position: center center;
+             ">
+        </div>
+        <div class="u-flexible-container"
+             style="
+               background-image:url(http://placekitten.com/700/394);
+               background-position: center center;
+               background-size: cover;
+             ">
+        </div>
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container
+      notes:
+        - "If you're not using the video or object elements and all you need is
+          a proportionally cropped or scaling background image with a fluid
+          container then you can leave out u-flexible-container_inner."
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+    - name: 4-3 modifier
+      markup: |
+        <div class="u-flexible-container u-flexible-container__4-3">
+            <video
+              class="u-flexible-container_inner"
+              style="background:#75787B;"
+              controls>
+            </video>
+        </div>
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container.u-flexible-container__4-3
+            .u-flexible-container_inner
+      notes:
+        - "Create your own aspect ratios by using this modifier as an example."
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+  tags:
+    - cf-core
+*/
+.u-flexible-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+}
+.u-flexible-container_inner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.u-flexible-container__4-3 {
+  position: relative;
+  padding-bottom: 75%;
+  height: 0;
+}
+/* topdoc
+  name: Link mixins
+  family: cf-core
+  patterns:
+    - codenotes:
+        - .u-link__colors();
+      notes:
+        - "Pass this mixin no arguments to color your link states with the
+          following defaults: :link (default state) pacific, :hover pacific-50,
+          :focus: pacific, :visited teal, :active navy."
+    - codenotes:
+        - .u-link__colors(@c);
+      notes:
+        - "Pass this mixin one color to be used on all of the following
+          states of your link; :link (default state), :visited, :hover, :focus,
+          :active."
+    - codenotes:
+        - .u-link__colors(@c, @h);
+      notes:
+        - "Pass this mixin two colors to use the first color for the :link,
+          :visited, and :active states, and the second color for the :hover and
+          :focus states."
+    - codenotes:
+        - .u-link__colors(@c, @v, @h, @f, @a);
+      notes:
+        - "Pass this mixin five colors in 'love/hate' mnemonic order to color
+          :link, :visited, :hover, :focus, and :active states respectively."
+        - "Even though this mixin is basically the same as
+          .u-link__colors-base(@c, @v, @h, @f, @a); we encourage you to use
+          .u-link__colors(@c, @v, @h, @f, @a) to promote consistency."
+    - codenotes:
+        - .u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba);
+      notes:
+        - "Allows you to color text and the borders separately."
+        - "The first five colors in 'love/hate' mnemonic order will color text
+          for the :link, :visited, :hover, :focus, and :active states
+          respectively. The last five colors in 'love/hate' mnemonic order will
+          color the borders for the :link, :visited, :hover, :focus, and :active
+          states respectively."
+        - "Even though this mixin is basically the same as
+          .u-link__colors-base(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba); we
+          encourage you to use .u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba)
+          to promote consistency."
+    - codenotes:
+        - .u-link__colors-base(@c, @v, @h, @f, @a);
+      notes:
+        - "This is the base mixin that all .u-link__colors() mixins use. Please
+          refrain from using this mixin directly in order to promote a
+          consistent use of mixin names for coloring links throughout this
+          project. Remember that if you need to set colors for all states of a
+          link you should use .u-link__colors(@c, @v, @h, @f, @a)."
+    - codenotes:
+        - .u-link__border();
+      notes:
+        - "Forces the default bottom border on the :link and :hover states."
+    - codenotes:
+        - .u-link__no-border();
+      notes:
+        - "Turn off the default bottom border on the :link and :hover states."
+    - codenotes:
+        - .u-link__hover-border();
+      notes:
+        - "Turn off the default bottom border on the :link state and force a
+          bottom border on the :hover state."
+    - codenotes:
+        - .u-link-child__hover();
+      notes:
+        - "When a link has child elements you may want only certain children to
+          change color when the parent link is hovered.
+          Pass no arguments to this mixin to color the child element pacific
+          when the parent link is hovered."
+    - codenotes:
+        - .u-link-child__hover(@c);
+      notes:
+        - "Pass this mixin one color to color the child element when the parent
+          link is hovered."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Margin utilities
+  family: cf-core
+  patterns:
+    - name: Utility classes
+      codenotes:
+        - .u-m<p><#>;
+      notes:
+        - "Replace <p> with the first letter of the position ('t' for top or 'b'
+           for bottom) and <#> with the pixel value of the margin you want."
+        - "Available values: 0, 5, 10, 15, 20, 30, 45, 60."
+  tags:
+    - cf-core
+*/
+.u-mt0 {
+  margin-top: 0 !important;
+}
+.u-mb0 {
+  margin-bottom: 0 !important;
+}
+.u-mt5 {
+  margin-top: 5px !important;
+}
+.u-mb5 {
+  margin-bottom: 5px !important;
+}
+.u-mt10 {
+  margin-top: 10px !important;
+}
+.u-mb10 {
+  margin-bottom: 10px !important;
+}
+.u-mt15 {
+  margin-top: 15px !important;
+}
+.u-mb15 {
+  margin-bottom: 15px !important;
+}
+.u-mt20 {
+  margin-top: 20px !important;
+}
+.u-mb20 {
+  margin-bottom: 20px !important;
+}
+.u-mt30 {
+  margin-top: 30px !important;
+}
+.u-mb30 {
+  margin-bottom: 30px !important;
+}
+.u-mt45 {
+  margin-top: 45px !important;
+}
+.u-mb45 {
+  margin-bottom: 45px !important;
+}
+.u-mt60 {
+  margin-top: 60px !important;
+}
+.u-mb60 {
+  margin-bottom: 60px !important;
+}
+/* topdoc
+  name: Width utilities
+  family: cf-core
+  patterns:
+    - name: Percent-based
+      markup: |
+        <div class="u-w100pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w100pct</code>
+        </div>
+        <div class="u-w90pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w90pct</code>
+        </div>
+        <div class="u-w80pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w80pct</code>
+        </div>
+        <div class="u-w70pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w70pct</code>
+        </div>
+        <div class="u-w60pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w60pct</code>
+        </div>
+        <div class="u-w50pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w50pct</code>
+        </div>
+        <div class="u-w40pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w40pct</code>
+        </div>
+        <div class="u-w30pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w30pct</code>
+        </div>
+        <div class="u-w20pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w20pct</code>
+        </div>
+        <div class="u-w10pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w10pct</code>
+        </div>
+        <div class="u-w75pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w75pct</code>
+        </div>
+        <div class="u-w25pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w25pct</code>
+        </div>
+        <div class="u-w66pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w66pct</code>
+        </div>
+        <div class="u-w33pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w33pct</code>
+        </div>
+      notes:
+        - "Inline styles are for demonstration purposes only, please don't use
+           them."
+  tags:
+    - cf-core
+*/
+.u-w100pct {
+  width: 100%;
+}
+.u-w90pct {
+  width: 90%;
+}
+.u-w80pct {
+  width: 80%;
+}
+.u-w70pct {
+  width: 70%;
+}
+.u-w60pct {
+  width: 60%;
+}
+.u-w50pct {
+  width: 50%;
+}
+.u-w40pct {
+  width: 40%;
+}
+.u-w30pct {
+  width: 30%;
+}
+.u-w20pct {
+  width: 20%;
+}
+.u-w10pct {
+  width: 10%;
+}
+.u-w75pct {
+  width: 75%;
+}
+.u-w25pct {
+  width: 25%;
+}
+.u-w66pct {
+  width: 66.66666667%;
+}
+.u-w33pct {
+  width: 33.33333333%;
+}
+/* topdoc
+  name: Width-specific display
+  family: cf-core
+  patterns:
+    - name: Show on mobile
+      markup: |
+        <section>
+            <p>The the text in the box below is visible only at widths less than 600px</p>
+            <div style="border: 1px solid black; height: 22px; padding: 5px;">
+                <p class="u-show-on-mobile">Visible on mobile</p>
+            </div>
+        </section>
+      codenotes:
+        - ".u-show-on-mobile"
+        - "Uses 'display:block' to toggle display. Would need to be extended
+          for inline use cases."
+      notes:
+        - "Displays an element only at mobile widths."
+    - name: Hide on mobile
+      markup: |
+        <section>
+            <p>The text in the box below is hidden at widths less than 600px</p>
+            <div style="border: 1px solid black; height: 22px; padding: 5px;">
+                <p class="u-hide-on-mobile">Hidden on mobile</p>
+            </div>
+        </section>
+      codenotes:
+        - ".u-hide-on-mobile"
+      notes:
+        - "Hides an element at mobile widths"
+  tags:
+    - cf-core
+*/
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+.u-show-on-mobile {
+  display: none;
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+/* topdoc
+  name: Small text utility
+  family: cf-core
+  patterns:
+    - name: .u-small-text (utility class)
+      markup: |
+        Lorem ipsum<br>
+        <span class="u-small-text">dolor sit amet</span>
+      codenotes:
+        - ".u-small-text"
+      notes:
+        - "14px text."
+        - "The utility class should only be used when the default text size is
+           16px. For example you wouldn't want to use the class inside of an
+           `h1` because the `font-size` in the `h1` will make `.u-small-text`
+           bigger than it should be. See the docs for the `.u-small-text()`
+           mixin."
+    - name: .u-small-text() (Less mixin)
+      codenotes:
+        - ".u-small-text(@context)"
+        - |
+          // Mixin usage:
+          .example {
+            font-size: unit(20px / @base-font-size-px, em);
+            small {
+              .u-small-text(20px);
+            }
+          }
+          // Compiles to:
+          .example {
+            font-size: 1.25em;
+          }
+          .example small {
+            font-size: 0.7em;
+          }
+      notes:
+        - "This mixin enables you to easily create consistent small text by
+           passing the context `font-size`."
+  tags:
+    - cf-core
+*/
+.u-small-text {
+  font-size: 0.875em;
+}
+small {
+  font-size: 0.875em;
+}
+/* topdoc
+    name: EOF
+    eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Base styles
+   ========================================================================== */
+/* topdoc
+  name: Webfonts
+  family: cf-core
+  patterns:
+    - name: Webfont mixins and variables
+      codenotes:
+        - ".webfont-regular()"
+        - ".webfont-italic()"
+        - ".webfont-medium()"
+        - ".webfont-demi()"
+      notes:
+        - "Use these mixins to easily add the your preferred font family to your
+          elements."
+        - "To use your own fonts in the webfont mixins, set your own font with the
+          @webfont-regular/italic/medium/demi variables."
+        - "To avoid faux bold and italics,
+          you must use the font family name for that particular style.
+          For example, when defining an italic in Helvetica
+          you need to use the Helvetica Italic font family.
+          Use the mixins when setting bold or italic text as they also
+          set the appropriate font-weight and font-style."
+        - "These mixins also add the appropriate .lt-ie9 overrides.
+          .lt-ie9 overrides are necessary to override font-style and font-weight
+          each time the webfont is used. These overrides are built into the webfont
+          mixins so you get them automatically. Note that this requires you to
+          use conditional classes on the <html> element:
+          https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md#conditional-html-classes."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Type hierarchy
+  family: cf-core
+  patterns:
+    - name: Default body type
+      markup: |
+        <p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    - name: Heading level 1
+      markup: |
+        <h1>Example heading element</h1>
+        <p class="h1">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h2.
+    - name: Heading level 2
+      markup: |
+        <h2>Example heading element</h2>
+        <p class="h2">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h3.
+    - name: Heading level 3
+      markup: |
+        <h3>Example heading element</h3>
+        <p class="h3">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h4.
+    - name: Heading level 4
+      markup: |
+        <h4>Example heading element</h4>
+        <p class="h4">A non-heading element</p>
+    - name: Heading level 5
+      markup: |
+        <h5>Example heading element</h5>
+        <p class="h5">A non-heading element</p>
+    - name: Heading level 6
+      markup: |
+        <h6>Example heading element</h6>
+        <p class="h6">A non-heading element</p>
+    - name: Lead paragraph
+      markup: |
+        <p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      notes:
+        - Responsive. Displays as an h3 on large screens; displays at h4 size (but still Regular weight) on small screens.
+    - name: Display heading (aka "superheading")
+      markup: |
+        <h1 class="superheading">Example display heading</h1>
+  tags:
+    - cf-core
+*/
+body {
+  color: #212121;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 100%;
+  line-height: 1.375;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+}
+h1,
+.h1 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.44117647em;
+  font-size: 2.125em;
+  line-height: 1.25;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+p + h1,
+p + .h1,
+ul + h1,
+ul + .h1,
+ol + h1,
+ol + .h1,
+dl + h1,
+dl + .h1,
+figure + h1,
+figure + .h1,
+img + h1,
+img + .h1,
+table + h1,
+table + .h1,
+blockquote + h1,
+blockquote + .h1 {
+  margin-top: 1.76470588em;
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+h2,
+.h2 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.57692308em;
+  font-size: 1.625em;
+  line-height: 1.25;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+p + h2,
+p + .h2,
+ul + h2,
+ul + .h2,
+ol + h2,
+ol + .h2,
+dl + h2,
+dl + .h2,
+figure + h2,
+figure + .h2,
+img + h2,
+img + .h2,
+table + h2,
+table + .h2,
+blockquote + h2,
+blockquote + .h2 {
+  margin-top: 1.73076923em;
+}
+h1 + h2,
+h1 + .h2,
+.h1 + h2,
+.h1 + .h2,
+h3 + h2,
+h3 + .h2,
+.h3 + h2,
+.h3 + .h2,
+h4 + h2,
+h4 + .h2,
+.h4 + h2,
+.h4 + .h2,
+h5 + h2,
+h5 + .h2,
+.h5 + h2,
+.h5 + .h2,
+h6 + h2,
+h6 + .h2,
+.h6 + h2,
+.h6 + .h2 {
+  margin-top: 1.15384615em;
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+h3,
+.h3 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+p + h3,
+p + .h3,
+ul + h3,
+ul + .h3,
+ol + h3,
+ol + .h3,
+dl + h3,
+dl + .h3,
+figure + h3,
+figure + .h3,
+img + h3,
+img + .h3,
+table + h3,
+table + .h3,
+blockquote + h3,
+blockquote + .h3,
+h1 + h3,
+h1 + .h3,
+.h1 + h3,
+.h1 + .h3,
+h2 + h3,
+h2 + .h3,
+.h2 + h3,
+.h2 + .h3,
+h4 + h3,
+h4 + .h3,
+.h4 + h3,
+.h4 + .h3,
+h5 + h3,
+h5 + .h3,
+.h5 + h3,
+.h5 + .h3,
+h6 + h3,
+h6 + .h3,
+.h6 + h3,
+.h6 + .h3 {
+  margin-top: 1.36363636em;
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+h4,
+.h4 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  margin-bottom: 0.83333333em;
+  font-size: 1.125em;
+  line-height: 1.25;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+p + h4,
+p + .h4,
+ul + h4,
+ul + .h4,
+ol + h4,
+ol + .h4,
+dl + h4,
+dl + .h4,
+figure + h4,
+figure + .h4,
+img + h4,
+img + .h4,
+table + h4,
+table + .h4,
+blockquote + h4,
+blockquote + .h4,
+h1 + h4,
+h1 + .h4,
+.h1 + h4,
+.h1 + .h4,
+h2 + h4,
+h2 + .h4,
+.h2 + h4,
+.h2 + .h4,
+h3 + h4,
+h3 + .h4,
+.h3 + h4,
+.h3 + .h4,
+h5 + h4,
+h5 + .h4,
+.h5 + h4,
+.h5 + .h4,
+h6 + h4,
+h6 + .h4,
+.h6 + h4,
+.h6 + .h4 {
+  margin-top: 1.66666667em;
+}
+h5,
+.h5 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+p + h5,
+p + .h5,
+ul + h5,
+ul + .h5,
+ol + h5,
+ol + .h5,
+dl + h5,
+dl + .h5,
+figure + h5,
+figure + .h5,
+img + h5,
+img + .h5,
+table + h5,
+table + .h5,
+blockquote + h5,
+blockquote + .h5,
+h1 + h5,
+h1 + .h5,
+.h1 + h5,
+.h1 + .h5,
+h2 + h5,
+h2 + .h5,
+.h2 + h5,
+.h2 + .h5,
+h3 + h5,
+h3 + .h5,
+.h3 + h5,
+.h3 + .h5,
+h4 + h5,
+h4 + .h5,
+.h4 + h5,
+.h4 + .h5,
+h6 + h5,
+h6 + .h5,
+.h6 + h5,
+.h6 + .h5 {
+  margin-top: 2.14285714em;
+}
+h6,
+.h6 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.25em;
+  font-size: 0.75em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+p + h6,
+p + .h6,
+ul + h6,
+ul + .h6,
+ol + h6,
+ol + .h6,
+dl + h6,
+dl + .h6,
+figure + h6,
+figure + .h6,
+img + h6,
+img + .h6,
+table + h6,
+table + .h6,
+blockquote + h6,
+blockquote + .h6,
+h1 + h6,
+h1 + .h6,
+.h1 + h6,
+.h1 + .h6,
+h2 + h6,
+h2 + .h6,
+.h2 + h6,
+.h2 + .h6,
+h3 + h6,
+h3 + .h6,
+.h3 + h6,
+.h3 + .h6,
+h4 + h6,
+h4 + .h6,
+.h4 + h6,
+.h4 + .h6,
+h5 + h6,
+h5 + .h6,
+.h5 + h6,
+.h5 + .h6 {
+  margin-top: 2.5em;
+}
+.lead-paragraph,
+.subheader,
+.subheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+  margin-top: 1.36363636em;
+  margin-bottom: 0.83333333em;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+.superheading,
+.superheader,
+.superheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.41666667em;
+  font-size: 3em;
+  line-height: 1.25;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+/* topdoc
+  name: Body copy element vertical margins
+  family: cf-core
+  patterns:
+    - name: Consistent vertical margins
+      notes:
+        - Applies 15px bottom margin to all p, ul, ol, dl, figure, table, and blockquote elements.
+        - Applies -5px top margin to lists following paragraphs to reduce margin between them to 10px.
+        - Applies 8px bottom margin to list items that are not within a nav element.
+        - Assumes that the font size of each of these items remains the default.
+      markup: |
+        <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
+        <p>Paragraph margin example</p>
+  tags:
+    - cf-core
+*/
+p,
+ul,
+ol,
+dl,
+figure,
+table,
+blockquote {
+  margin-top: 0;
+  margin-bottom: 0.9375em;
+}
+p + ul,
+p + ol {
+  margin-top: -0.3125em;
+}
+:not(nav) li {
+  margin-bottom: 0.5em;
+}
+.lt-ie9 nav li {
+  margin-bottom: 0;
+}
+/* topdoc
+  name: Default link
+  notes:
+    - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+      be used in production."
+  family: cf-core
+  patterns:
+    - name: Default state
+      markup: |
+        <a href="#">Default link style</a>
+    - name: Visited state
+      markup: |
+        <a href="#" class="visited">Visited link style</a>
+    - name: Hovered state
+      markup: |
+        <a href="#" class="hover">Hovered link style</a>
+    - name: Focused state
+      markup: |
+        <a href="#" class="focus">Focused link style</a>
+    - name: Active state
+      markup: |
+        <a href="#" class="active">Active link style</a>
+  tags:
+    - cf-core
+*/
+a {
+  border-width: 0;
+  border-style: dotted;
+  border-color: #0071bc;
+  color: #0071bc;
+  text-decoration: none;
+}
+a:visited,
+a.visited {
+  border-color: #4c2c92;
+  color: #4c2c92;
+}
+a:hover,
+a.hover {
+  border-style: solid;
+  border-color: #205493;
+  color: #205493;
+}
+a:focus,
+a.focus {
+  border-style: solid;
+  outline: thin dotted;
+}
+a:active,
+a.active {
+  border-style: solid;
+  border-color: #046b99;
+  color: #046b99;
+}
+/* topdoc
+  name: Underlined links
+  family: cf-core
+  patterns:
+    - name: States
+      notes:
+        - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+          be used in production."
+        - "The underline style properties are mostly set above in the a tag.
+          To enable the underline simply set a bottom-border-width as done here."
+      markup: |
+        <p>
+            <a href="#">Default</a>,
+            <a href="#" class="visited">Visited</a>,
+            <a href="#" class="hover">Hovered</a>,
+            <a href="#" class="focus">Focused</a>,
+            <a href="#" class="active">Active</a>
+        </p>
+    - name: Underline conditions
+      notes:
+        - "We're restricting link borders to links within p, li, and dd so that
+          we don't have to override them every time we want a plain link."
+      markup: |
+        <p>
+            <a href="#">A child of a paragraph</a>
+        </p>
+        <ul>
+            <li>
+                <a href="#">A child of a list item</a>
+            </li>
+        </ul>
+        <dl>
+            <dt>
+                Definition list term
+            </dt>
+            <dd>
+                <a href="#">A child of a definition list description</a>
+            </dd>
+        </dl>
+    - name: Exceptions for underlined links
+      notes:
+        - "Inline text links inside of a nav element are not underlined."
+      markup: |
+        <nav>
+            <p>
+                <a href="#">A child of a paragraph</a>
+            </p>
+            <ul>
+                <li>
+                    <a href="#">A child of a list item</a>
+                </li>
+            </ul>
+            <dl>
+                <dt>
+                    Definition list term
+                </dt>
+                <dd>
+                    <a href="#">A child of a definition list description</a>
+                </dd>
+            </dl>
+        </nav>
+  tags:
+    - cf-core
+*/
+p a,
+li a,
+dd a {
+  border-bottom-width: 1px;
+}
+nav a {
+  border-bottom-width: 0;
+}
+/* topdoc
+  name: Lists
+  family: cf-core
+  patterns:
+    - name: Unordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
+    - name: Ordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ol>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ol>
+  tags:
+    - cf-core
+*/
+ul {
+  padding-left: 2em;
+  list-style: square;
+}
+ol {
+  padding-left: 1.9375em;
+}
+ol > li {
+  padding-left: 0.0625em;
+}
+/* topdoc
+  name: Tables
+  family: cf-core
+  patterns:
+    - name: Standard table
+      markup: |
+        <table>
+            <thead>
+                <tr>
+                    <th>Column 1 header</th>
+                    <th>Column 2 header</th>
+                    <th>Column 3 header</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Row 1, column 1</td>
+                    <td>Row 1, column 2</td>
+                    <td>Row 1, column 3</td>
+                </tr>
+                <tr>
+                    <td>Row 2, column 1</td>
+                    <td>Row 2, column 2</td>
+                    <td>Row 2, column 3</td>
+                </tr>
+                <tr>
+                    <td>Row 3, column 1</td>
+                    <td>Row 3, column 2</td>
+                    <td>Row 3, column 3</td>
+                </tr>
+            </tbody>
+        </table>
+  tags:
+    - cf-core
+*/
+table {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+th,
+td {
+  padding: 0.625em;
+}
+thead th,
+thead td {
+  color: #212121;
+  background: #f1f1f1;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+thead,
+tbody tr {
+  border-bottom: 1px solid #5b616b;
+}
+th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  text-align: left;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+tbody th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+/* topdoc
+  name: Block quote
+  family: cf-core
+  patterns:
+    - name: Default block quote
+      markup: |
+        <blockquote cite="link-to-source">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Culpa
+            similique fugit hic eligendi praesentium officiis illum optio iusto
+            commodi eum tempore nisi ad in perferendis enim quo dolores.
+            Reprehenderit similique earum quibusdam possimus vitae esse
+            nesciunt mollitia sed beatae aliquid dolores iure a impedit quam
+            minus eum modi illum ducimus eligendi eveniet labore non sequi
+            voluptate et totam praesentium animi itaque asperiores dolorum
+            sunt laudantium repellat nam commodi. Perspiciatis natus aliquam
+            veniam officiis ducimus voluptatum ut necessitatibus non!
+        </blockquote>
+      notes:
+        - "Use a block quote to quote from an external work. See .pull-quote if
+          you need to highlight an excerpt from the current work."
+        - "It is best practice to document the URL of a quoted work using the
+          cite attribute."
+  tags:
+    - cf-core
+*/
+blockquote {
+  margin-right: 0.9375em;
+  margin-left: 0.9375em;
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+/* topdoc
+    name: Form labels
+    family: cf-core
+    notes:
+      - "Visit https://github.com/cfpb/cf-forms for advanced form label patterns."
+    patterns:
+    - name: Default label
+      markup: |
+        <label>Form label</label>
+    - name: Label wrapping a radio or checkbox
+      markup: |
+        <label>
+            <input type="radio">
+            Radio label
+        </label>
+        <label>
+            <input type="checkbox">
+            Checkbox label
+        </label>
+    tags:
+    - cf-core
+*/
+label {
+  display: block;
+  margin-bottom: 0.3125em;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
 }
 .lt-ie9 label strong,
 .lt-ie9 label b {
@@ -4275,6 +9600,14 @@ figure img {
 .lt-ie8 .expandable_content {
   zoom: 1;
 }
+.expandable_content:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.lt-ie8 .expandable_content {
+  zoom: 1;
+}
 /* topdoc
   name: Expandable text elements
   family: cf-expandables
@@ -4311,6 +9644,9 @@ figure img {
 .lt-ie9 .expandable_label {
   font-weight: normal !important;
 }
+.lt-ie9 .expandable_label {
+  font-weight: normal !important;
+}
 .expandable_link {
   color: #046b99;
   font-family: Arial, Arial, sans-serif;
@@ -4329,11 +9665,47 @@ figure img {
 .lt-ie9 .expandable_link i {
   font-style: normal !important;
 }
+.lt-ie9 .expandable_link em,
+.lt-ie9 .expandable_link i {
+  font-style: normal !important;
+}
 .expandable_link strong,
 .expandable_link b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 .expandable_link strong,
+.lt-ie9 .expandable_link b {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable_link strong,
+.lt-ie9 .expandable_link b {
+  font-weight: normal !important;
+}
+.expandable_link em,
+.expandable_link i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .expandable_link em,
+.lt-ie9 .expandable_link i {
+  font-style: normal !important;
+}
+.lt-ie9 .expandable_link em,
+.lt-ie9 .expandable_link i {
+  font-style: normal !important;
+}
+.expandable_link strong,
+.expandable_link b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .expandable_link strong,
+.lt-ie9 .expandable_link b {
+  font-weight: normal !important;
 }
 .lt-ie9 .expandable_link strong,
 .lt-ie9 .expandable_link b {
@@ -4454,6 +9826,14 @@ figure img {
 */
 .expandable_header {
   display: block;
+}
+.expandable_header:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.lt-ie8 .expandable_header {
+  zoom: 1;
 }
 .expandable_header:after {
   content: "";
@@ -4716,12 +10096,21 @@ button.expandable_header {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-bottom: 0.35714286em;
+  margin-bottom: 1.07142857em;
   font-size: 0.875em;
-  line-height: 1.57142857;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
   margin-bottom: 0;
+}
+.lt-ie9 .expandable-group_header {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable-group_header {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable-group_header {
+  font-weight: normal !important;
 }
 .lt-ie9 .expandable-group_header {
   font-weight: normal !important;
@@ -4735,10 +10124,19 @@ button.expandable_header {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: 500;
-  margin-bottom: 1.16666667em;
+  margin-bottom: 0.83333333em;
   font-size: 1.125em;
-  line-height: 1.22222222;
+  line-height: 1.25;
   margin-bottom: 0;
+}
+.lt-ie9 .expandable-group .expandable_label {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable-group .expandable_label {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable-group .expandable_label {
+  font-weight: normal !important;
 }
 .lt-ie9 .expandable-group .expandable_label {
   font-weight: normal !important;
@@ -4750,4 +10148,4 @@ button.expandable_header {
   name: EOF
   eof: true
 */
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1jc3Mvbm9ybWFsaXplLmNzcyIsIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1sZWdhY3ktYWRkb24vbm9ybWFsaXplLWxlZ2FjeS1hZGRvbi5jc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtdXRpbGl0aWVzLmxlc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtbWVkaWEtcXVlcmllcy5sZXNzIiwiLy4uL2NmLWNvcmUvc3JjL2NmLWJhc2UubGVzcyIsIi8uLi9jZi1jb3JlL3NyYy9jZi12YXJzLmxlc3MiLCIvLi4vY2YtaWNvbnMvc3JjL2NmLWljb25zLmxlc3MiLCIvc3JjL2NmLWV4cGFuZGFibGVzLmxlc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7OztBQVFBO0VBQ0UsdUJBQUE7O0VBQ0EsMEJBQUE7O0VBQ0EsOEJBQUE7Ozs7OztBQU9GO0VBQ0UsU0FBQTs7Ozs7Ozs7OztBQWFGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7QUFDQTtBQUNBO0FBQ0E7RUFDRSxxQkFBQTs7RUFDQSx3QkFBQTs7Ozs7OztBQVFGLEtBQUssSUFBSTtFQUNQLGFBQUE7RUFDQSxTQUFBOzs7Ozs7QUFRRjtBQUNBO0VBQ0UsYUFBQTs7Ozs7OztBQVVGO0VBQ0UsNkJBQUE7Ozs7OztBQVFGLENBQUM7QUFDRCxDQUFDO0VBQ0MsVUFBQTs7Ozs7OztBQVVGLElBQUk7RUFDRix5QkFBQTs7Ozs7QUFPRjtBQUNBO0VBQ0UsaUJBQUE7Ozs7O0FBT0Y7RUFDRSxrQkFBQTs7Ozs7O0FBUUY7RUFDRSxjQUFBO0VBQ0EsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSxnQkFBQTtFQUNBLFdBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7RUFDRSxjQUFBO0VBQ0EsY0FBQTtFQUNBLGtCQUFBO0VBQ0Esd0JBQUE7O0FBR0Y7RUFDRSxXQUFBOztBQUdGO0VBQ0UsZUFBQTs7Ozs7OztBQVVGO0VBQ0UsU0FBQTs7Ozs7QUFPRixHQUFHLElBQUk7RUFDTCxnQkFBQTs7Ozs7OztBQVVGO0VBQ0UsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSx1QkFBQTtFQUNBLFNBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsaUNBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7OztBQWtCRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7RUFDQSxhQUFBOztFQUNBLFNBQUE7Ozs7OztBQU9GO0VBQ0UsaUJBQUE7Ozs7Ozs7O0FBVUY7QUFDQTtFQUNFLG9CQUFBOzs7Ozs7Ozs7QUFXRjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0gsMEJBQUE7O0VBQ0EsZUFBQTs7Ozs7O0FBT0YsTUFBTTtBQUNOLElBQUssTUFBSztFQUNSLGVBQUE7Ozs7O0FBT0YsTUFBTTtBQUNOLEtBQUs7RUFDSCxTQUFBO0VBQ0EsVUFBQTs7Ozs7O0FBUUY7RUFDRSxtQkFBQTs7Ozs7Ozs7O0FBV0YsS0FBSztBQUNMLEtBQUs7RUFDSCxzQkFBQTs7RUFDQSxVQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsWUFBQTs7Ozs7O0FBUUYsS0FBSztFQUNILDZCQUFBOztFQUNBLHVCQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsd0JBQUE7Ozs7O0FBT0Y7RUFDRSx5QkFBQTtFQUNBLGFBQUE7RUFDQSw4QkFBQTs7Ozs7O0FBUUY7RUFDRSxTQUFBOztFQUNBLFVBQUE7Ozs7OztBQU9GO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7RUFDRSxpQkFBQTs7Ozs7OztBQVVGO0VBQ0UseUJBQUE7RUFDQSxpQkFBQTs7QUFHRjtBQUNBO0VBQ0UsVUFBQTs7Ozs7Ozs7O0FDNVpGO0FBQ0E7QUFDQTtFQUNJLGdCQUFBO0VBQ0EsUUFBQTs7Ozs7Ozs7O0FBWUo7RUFDSSxlQUFBOzs7Ozs7QUFRSjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksdUJBQUE7Ozs7Ozs7Ozs7QUFhSjtFQUNJLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsYUFBQTs7QUFHSjtFQUNJLGNBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7Ozs7O0FBT0o7QUFDQTtFQUNJLGFBQUE7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSxjQUFjLHdCQUFkOzs7OztBQU9KO0VBQ0ksZ0JBQUE7RUFDQSxxQkFBQTs7Ozs7QUFPSjtFQUNJLFlBQUE7Ozs7O0FBT0osQ0FBQztBQUNELENBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxhQUFBOzs7Ozs7OztBQVdKO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtFQUNJLGtCQUFBOzs7OztBQU9KO0FBQ0E7QUFDQTtFQUNJLG1CQUFBOzs7OztBQU9KLEdBQUk7QUFDSixHQUFJO0VBQ0EsZ0JBQUE7RUFDQSxzQkFBQTs7Ozs7Ozs7QUFXSjtFQUNJLCtCQUFBOzs7Ozs7OztBQVdKO0VBQ0ksU0FBQTs7Ozs7OztBQVNKO0VBQ0ksU0FBQTs7RUFDQSxtQkFBQTs7RUFDQSxrQkFBQTs7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSx3QkFBQTtFQUNBLHVCQUFBOzs7Ozs7QUFRSjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0Qsa0JBQUE7Ozs7OztBQVFKLEtBQUs7QUFDTCxLQUFLO0VBQ0QsYUFBQTtFQUNBLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDOU1BLE1BQU87RUFDSCx3QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF5QkosV0FBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBOztBQUVKLE9BQVE7RUFDSixPQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMEJSO0VBQ0Usa0JBQUE7RUFDQSxnQkFBQTtFQUNBLE1BQU0sYUFBTjtFQUNBLFdBQUE7RUFBYSxVQUFBO0VBQ2IsWUFBQTtFQUFjLFVBQUE7RUFBWSxTQUFBOzs7Ozs7Ozs7Ozs7OztBQWlCNUI7RUFDSSxxQkFBQTs7QUFDQSxPQUFRO0VBRUosZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3QlI7RUFDSSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvQ0o7RUFDSSxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbUhKO0VBTEksa0JBQUE7RUFDQSxzQkFBQTtFQUNBLFNBQUE7O0FBT0o7RUFDSSxrQkFBQTtFQUNBLE1BQUE7RUFDQSxPQUFBO0VBQ0EsV0FBQTtFQUNBLFlBQUE7O0FBR0o7RUFqQkksa0JBQUE7RUFDQSxtQkFBQTtFQUNBLFNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb05KO0VBQVUsd0JBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDBCQUFBOztBQUNWO0VBQVUsNkJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMERWO0VBQWEsV0FBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsbUJBQUE7O0FBQ2I7RUFBYSxtQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUM5ZmIscUJBSDBDO0VBRzFDO0lEcWlCUSxhQUFBOzs7QUFJUjtFQUNJLGFBQUE7O0FDMWlCSixxQkFIMEM7RUFHMUM7SUQ0aUJRLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbURSO0VBSEUsa0JBQUE7O0FBT0Y7RUFQRSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRXJpQkY7RUFDSSxjQUFBO0VBQ0Esc0JBQXNCLHdCQUF0QjtFQUNBLGVBQUE7RUFDQSxrQkFBQTs7QUFxRUo7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtBQUNBO0VBL0tJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXNHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBdEdBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUREUixxQkFIMEM7RUFHMUM7RUFBQTtJQ3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUFnSEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLHVCQUFBOztFQWhIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFQUNBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFQUNBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7OztBQWlKUjtBQUNBO0VBeExJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQWdIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBaEhBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUREUixxQkFIMEM7RUFHMUM7RUFBQTtJQ3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUEwSEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLHVCQUFBOztFQTFIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFQUNBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFQUNBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7OztBQTBKUjtBQUNBO0VBak1JLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQTBIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBMUhBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUREUixxQkFIMEM7RUFHMUM7RUFBQTtJQ1pJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQTJHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsdUJBQUE7O0VBNUdBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBQTRLUjtBQUNBO0VBakxJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQTJHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBNUdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBaUxSO0FBQ0E7RUE3S0kscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBMkdBLG1CQUFBO0VBQ0EseUJBQUE7RUFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBaEhBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBNktSO0FBQ0E7RUFsTEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBd0hBLG1CQUFBO0VBQ0EseUJBQUE7RUFHQSwyQkFBQTtFQUNBLGlCQUFBO0VBQ0EsdUJBQUE7O0FBN0hBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBa0xSO0VBN0xJLGdCQUFBO0VBMkdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSx1QkFBQTtFQXhJQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBMEJBLE9BQVE7RUFDSiw4QkFBQTs7QUF6QkosVUFBRTtBQUNGLFVBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxXQWZOO0FBZUYsT0FBUSxXQWROO0VBZUUsNkJBQUE7O0FBWEosVUFBRTtBQUNGLFVBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBQUNBLE9BQVEsV0E1Qk47QUE0QkYsT0FBUSxXQTNCTjtFQTRCRSw4QkFBQTs7QUF1TFI7RUEzTEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBaU1BLHVCQUFBO0VBQ0EsY0FBQTtFQUNBLGlCQUFBOztBQWxNQSxPQUFRO0VBQ0osOEJBQUE7Ozs7Ozs7Ozs7Ozs7OztBQW1OUjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDSSxhQUFBO0VBRUEscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQThCSjtFQUNJLGVBQUE7RUFDQSxvQkFBQTtFQUNBLHFCQUFBO0VBQ0EsY0FBQTtFQUNBLHFCQUFBOztBQUVBLENBQUM7QUFDRCxDQUFDO0VBQ0cscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7O0FBR0osQ0FBQztBQUNELENBQUM7RUFDRyxtQkFBQTtFQUNBLG9CQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNFUixDQUtJO0FBSkosRUFJSTtBQUhKLEVBR0k7RUFDSSx3QkFBQTs7QUFJUixHQUFJO0VBRUEsc0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7QUFtQko7RUFDSSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXdDSjtFQTNjSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBRUEsS0FBRTtBQUNGLEtBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FBWEosS0FBRTtBQUNGLEtBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBQUNBLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUF5YVI7QUFDQTtFQUNJLGdCQUFBOztBQUVBLEtBQU07QUFBTixLQUFNO0VBQ0YsY0FBQTtFQUNBLG1CQUFBO0VBbmJKLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQTJHQSxtQkFBQTtFQUNBLHlCQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBOztBQWhIQSxPQUFRLE1BOGFGO0FBOWFOLE9BQVEsTUE4YUY7RUE3YUYsOEJBQUE7O0FBb2JSO0FBQ0EsS0FBTTtFQUNGLGdDQUFBOztBQUdKO0VBN2JJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQTZiQSxnQkFBQTs7QUE1YkEsT0FBUTtFQUNKLDhCQUFBOztBQThiUixLQUFNO0VBcGVGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFFQSxLQWdlRSxHQWhlQTtBQUNGLEtBK2RFLEdBL2RBO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUNBLE9BQVEsTUFpZE4sR0FoZUE7QUFlRixPQUFRLE1BaWROLEdBL2RBO0VBZUUsNkJBQUE7O0FBWEosS0EyZEUsR0EzZEE7QUFDRixLQTBkRSxHQTFkQTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxNQStiTixHQTNkQTtBQTRCRixPQUFRLE1BK2JOLEdBMWRBO0VBNEJFLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE0ZFI7RUFFSSxjQUFBOztBRHRlSixxQkFIMEM7RUFHMUM7SUN5ZVEsb0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE2QlI7RUFDSSxjQUFBO0VBRUEsdUJBQUE7RUF2aUJBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFFQSxLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFDQSxPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBQThmUixLQU1JLE1BQUs7QUFOVCxLQU9JLE1BQUs7RUFDRCxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXVFUixLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTDtBQUNBLE1BQU07RUFHRixxQkFBQTtFQUNBLFNBQUE7RUFDQSxnQkFBQTtFQUNBLDhCQUFBO0VBQ0EsY0FBQTtFQUNBLG1CQUFBO0VBQ0EseUJBQUE7RUFDQSxnQkFBQTtFQUNBLG1CQUFBO0VBQ0Esd0JBQUE7RUFDQSw4Q0FBQTs7QUFLSjtFQUNJLHdCQUFBOztBQUtKLEtBQUssYUFBYTtBQUNsQixLQUFLLGFBQWE7QUFDbEIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtBQUNwQixLQUFLLGNBQWM7QUFDbkIsS0FBSyxjQUFjO0FBQ25CLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0FBQ3BCLFFBQVE7QUFDUixRQUFRO0FBQ1IsTUFBTSxVQUFVO0FBQ2hCLE1BQU0sVUFBVTtFQUNaLHlCQUFBO0VBQ0EsMEJBQUE7RUFDQSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0csT0NqbkI2QixrQkRpbkI3Qjs7QUFFSDtFQUNHLE9DcG5CNkIsa0JEb25CN0I7O0FBRUg7RUFDRyxPQ3ZuQjZCLGtCRHVuQjdCOzs7Ozs7Ozs7Ozs7OztBQWlCSDtFQUNJLGVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzQko7RUFDSSxjQUFBO0VBQ0EsZUFBQTs7QUFGSixNQUlJO0VBRUksc0JBQUE7O0FBSVIsaUJBQWtCO0VBQ2QseUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRXBzQko7RUFDRSxhQUFhLGVBQWI7RUFDQSxTQUFTLHdCQUFUO0VBQ0EsU0FBUyxnQ0FBdUMsT0FBTywwQkFDakQsMEJBQWlDLE9BQU8sYUFDeEMseUJBQWdDLE9BQU8saUJBQ3ZDLHlCQUFnQyxPQUFPLE1BSDdDO0VBSUEsbUJBQUE7RUFDQSxrQkFBQTs7QUFnQkY7QUFDQSxDQUFDO0VBQ0MsYUFBYSxlQUFiO0VBQ0EscUJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsY0FBQTtFQUNBLG1DQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9RRixDQUFDLE9BQWlCO0VBQ2hCLHVCQUFBO0VBQ0EsbUJBQUE7RUFDQSxvQkFBQTs7QUFHRixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7QUFDekIsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7O0FBQ3pCLENBQUMsT0FBaUI7RUFBTyxjQUFBOztBQUN6QixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE2RHpCLENBQUMsT0FBaUI7RUFDaEIseUJBQUE7RUFDQSw0QkFBQTtFQUNBLG1CQUFBOztBQUdGLENBQUMsT0FBaUI7RUF6Q2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsYUFBbkI7RUFDSSxlQUFlLGFBQWY7RUFDSSxXQUFXLGFBQVg7O0FBdUNWLENBQUMsT0FBaUI7RUExQ2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsY0FBbkI7RUFDSSxlQUFlLGNBQWY7RUFDSSxXQUFXLGNBQVg7O0FBd0NWLENBQUMsT0FBaUI7RUEzQ2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsY0FBbkI7RUFDSSxlQUFlLGNBQWY7RUFDSSxXQUFXLGNBQVg7O0FBMENWLENBQUMsT0FBaUI7RUF0Q2hCLFFBQVEsa0VBQVI7RUFDQSxtQkFBbUIsWUFBbkI7RUFDSSxlQUFlLFlBQWY7RUFDSSxXQUFXLFlBQVg7O0FBb0NWLENBQUMsT0FBaUI7RUF2Q2hCLFFBQVEsa0VBQVI7RUFDQSxtQkFBbUIsWUFBbkI7RUFDSSxlQUFlLFlBQWY7RUFDSSxXQUFXLFlBQVg7O0FBc0NWLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7RUFDdEIsWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNCRixDQUFDLE9BQWlCO0VBQ2hCLDZDQUFBO0VBQ1EscUNBQUE7O0FBR1YsQ0FBQyxPQUFpQjtFQUNoQix1Q0FBdUMsUUFBdkM7RUFDUSwrQkFBK0IsUUFBL0I7O0FBR1Y7RUFDRTtJQUNFLG1CQUFtQixZQUFuQjtJQUNRLFdBQVcsWUFBWDs7RUFFVjtJQUNFLG1CQUFtQixjQUFuQjtJQUNRLFdBQVcsY0FBWDs7O0FBSVo7RUFDRTtJQUNFLG1CQUFtQixZQUFuQjtJQUNRLFdBQVcsWUFBWDs7RUFFVjtJQUNFLG1CQUFtQixjQUFuQjtJQUNRLFdBQVcsY0FBWDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBOENSLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbGZkLDZFQUFBOztBQXdmQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZmZCw2RUFBQTs7QUE2ZkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1ZmQsNkVBQUE7O0FBa2dCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpnQmQsNkVBQUE7O0FBdWdCQSxDQURILE9BQWlCLEdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRnQmQsNkVBQUE7O0FBNGdCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNnQmQsNkVBQUE7O0FBaWhCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhoQmQsNkVBQUE7O0FBc2hCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJoQmQsNkVBQUE7O0FBMmhCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFoQmQsNkVBQUE7O0FBZ2lCQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvaEJkLDZFQUFBOztBQXFpQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwaUJkLDZFQUFBOztBQTBpQkEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBemlCZCw2RUFBQTs7QUEraUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOWlCZCw2RUFBQTs7QUFvakJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmpCZCw2RUFBQTs7QUF5akJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGpCZCw2RUFBQTs7QUE4akJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdqQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3bUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdm1CZCw2RUFBQTs7QUE2bUJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNW1CZCw2RUFBQTs7QUFrbkJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBam5CZCw2RUFBQTs7QUF1bkJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdG5CZCw2RUFBQTs7QUE0bkJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM25CZCw2RUFBQTs7QUFpb0JBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaG9CZCw2RUFBQTs7QUFzb0JBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcm9CZCw2RUFBQTs7QUEyb0JBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMW9CZCw2RUFBQTs7QUFncEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL29CZCw2RUFBQTs7QUFxcEJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHBCZCw2RUFBQTs7QUEwcEJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenBCZCw2RUFBQTs7QUErcEJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXBCZCw2RUFBQTs7QUFvcUJBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnFCZCw2RUFBQTs7QUF5cUJBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHFCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW10QkEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsdEJkLDZFQUFBOztBQXd0QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2dEJkLDZFQUFBOztBQTZ0QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1dEJkLDZFQUFBOztBQWt1QkEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanVCZCw2RUFBQTs7QUF1dUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHVCZCw2RUFBQTs7QUE0dUJBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN1QmQsNkVBQUE7O0FBaXZCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh2QmQsNkVBQUE7O0FBc3ZCQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ2QmQsNkVBQUE7O0FBMnZCQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF2QmQsNkVBQUE7O0FBZ3dCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS92QmQsNkVBQUE7O0FBcXdCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB3QmQsNkVBQUE7O0FBMHdCQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp3QmQsNkVBQUE7O0FBK3dCQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl3QmQsNkVBQUE7O0FBb3hCQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFueEJkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwekJBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenpCZCw2RUFBQTs7QUErekJBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXpCZCw2RUFBQTs7QUFvMEJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbjBCZCw2RUFBQTs7QUF5MEJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeDBCZCw2RUFBQTs7QUE4MEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNzBCZCw2RUFBQTs7QUFtMUJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDFCZCw2RUFBQTs7QUF3MUJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdjFCZCw2RUFBQTs7QUE2MUJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNTFCZCw2RUFBQTs7QUFrMkJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBajJCZCw2RUFBQTs7QUF1MkJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXQyQmQsNkVBQUE7O0FBNDJCQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTMyQmQsNkVBQUE7O0FBaTNCQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgzQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQSs2QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5NkJkLDZFQUFBOztBQW83QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuN0JkLDZFQUFBOztBQXk3QkEsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4N0JkLDZFQUFBOztBQTg3QkEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3N0JkLDZFQUFBOztBQW04QkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsOEJkLDZFQUFBOztBQXc4QkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2OEJkLDZFQUFBOztBQTY4QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1OEJkLDZFQUFBOztBQWs5QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqOUJkLDZFQUFBOztBQXU5QkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0OUJkLDZFQUFBOztBQTQ5QkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzOUJkLDZFQUFBOztBQWkrQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoK0JkLDZFQUFBOztBQXMrQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyK0JkLDZFQUFBOztBQTIrQkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExK0JkLDZFQUFBOztBQWcvQkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvK0JkLDZFQUFBOztBQXEvQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwL0JkLDZFQUFBOztBQTAvQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6L0JkLDZFQUFBOztBQSsvQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5L0JkLDZFQUFBOztBQW9nQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuZ0NkLDZFQUFBOztBQXlnQ0EsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4Z0NkLDZFQUFBOztBQThnQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3Z0NkLDZFQUFBOztBQW1oQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsaENkLDZFQUFBOztBQXdoQ0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdmhDZCw2RUFBQTs7QUE2aENBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNWhDZCw2RUFBQTs7QUFraUNBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamlDZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFnb0NBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL25DZCw2RUFBQTs7QUFxb0NBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBvQ2QsNkVBQUE7O0FBMG9DQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXpvQ2QsNkVBQUE7O0FBK29DQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5b0NkLDZFQUFBOztBQW9wQ0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucENkLDZFQUFBOztBQXlwQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cENkLDZFQUFBOztBQThwQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3cENkLDZFQUFBOztBQW1xQ0EsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHFDZCw2RUFBQTs7QUF3cUNBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnFDZCw2RUFBQTs7QUE2cUNBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXFDZCw2RUFBQTs7QUFrckNBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpyQ2QsNkVBQUE7O0FBdXJDQSxDQURILE9BQWlCLHNCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0ckNkLDZFQUFBOztBQTRyQ0EsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzckNkLDZFQUFBOztBQWlzQ0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHNDZCw2RUFBQTs7QUFzc0NBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnNDZCw2RUFBQTs7QUEyc0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXNDZCw2RUFBQTs7QUFndENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3NDZCw2RUFBQTs7QUFxdENBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB0Q2QsNkVBQUE7O0FBMHRDQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp0Q2QsNkVBQUE7O0FBK3RDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl0Q2QsNkVBQUE7O0FBb3VDQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW51Q2QsNkVBQUE7O0FBeXVDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4dUNkLDZFQUFBOztBQTh1Q0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3VDZCw2RUFBQTs7QUFtdkNBLENBREgsT0FBaUIsMEJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWx2Q2QsNkVBQUE7O0FBd3ZDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ2Q2QsNkVBQUE7O0FBNnZDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1dkNkLDZFQUFBOztBQWt3Q0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqd0NkLDZFQUFBOztBQXV3Q0EsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHdDZCw2RUFBQTs7QUE0d0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3dDZCw2RUFBQTs7QUFpeENBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh4Q2QsNkVBQUE7O0FBc3hDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ4Q2QsNkVBQUE7O0FBMnhDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF4Q2QsNkVBQUE7O0FBZ3lDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEveENkLDZFQUFBOztBQXF5Q0EsQ0FESCxPQUFpQixzQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHlDZCw2RUFBQTs7QUEweUNBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenlDZCw2RUFBQTs7QUEreUNBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl5Q2QsNkVBQUE7O0FBb3pDQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW56Q2QsNkVBQUE7O0FBeXpDQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4ekNkLDZFQUFBOztBQTh6Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3ekNkLDZFQUFBOztBQW0wQ0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDBDZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBaStDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgrQ2QsNkVBQUE7O0FBcytDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXIrQ2QsNkVBQUE7O0FBMitDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTErQ2QsNkVBQUE7O0FBZy9DQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS8rQ2QsNkVBQUE7O0FBcS9DQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXAvQ2QsNkVBQUE7O0FBMC9DQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXovQ2QsNkVBQUE7O0FBKy9DQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTkvQ2QsNkVBQUE7O0FBb2dEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5nRGQsNkVBQUE7O0FBeWdEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhnRGQsNkVBQUE7O0FBOGdEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdnRGQsNkVBQUE7O0FBbWhEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxoRGQsNkVBQUE7O0FBd2hEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2aERkLDZFQUFBOztBQTZoREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1aERkLDZFQUFBOztBQWtpREEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamlEZCw2RUFBQTs7QUF1aURBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdGlEZCw2RUFBQTs7QUE0aURBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNpRGQsNkVBQUE7O0FBaWpEQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhqRGQsNkVBQUE7O0FBc2pEQSxDQURILE9BQWlCLG1CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyakRkLDZFQUFBOztBQTJqREEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExakRkLDZFQUFBOztBQWdrREEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL2pEZCw2RUFBQTs7QUFxa0RBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcGtEZCw2RUFBQTs7QUEwa0RBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBemtEZCw2RUFBQTs7QUEra0RBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOWtEZCw2RUFBQTs7QUFvbERBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5sRGQsNkVBQUE7O0FBeWxEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhsRGQsNkVBQUE7O0FBOGxEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdsRGQsNkVBQUE7O0FBbW1EQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxtRGQsNkVBQUE7O0FBd21EQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2bURkLDZFQUFBOztBQTZtREEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1bURkLDZFQUFBOztBQWtuREEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqbkRkLDZFQUFBOztBQXVuREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0bkRkLDZFQUFBOztBQTRuREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzbkRkLDZFQUFBOztBQWlvREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFob0RkLDZFQUFBOztBQXNvREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyb0RkLDZFQUFBOztBQTJvREEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExb0RkLDZFQUFBOztBQWdwREEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvb0RkLDZFQUFBOztBQXFwREEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwcERkLDZFQUFBOztBQTBwREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6cERkLDZFQUFBOztBQStwREEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5cERkLDZFQUFBOztBQW9xREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucURkLDZFQUFBOztBQXlxREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cURkLDZFQUFBOztBQThxREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3cURkLDZFQUFBOztBQW1yREEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsckRkLDZFQUFBOztBQXdyREEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2ckRkLDZFQUFBOztBQTZyREEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXJEZCw2RUFBQTs7QUFrc0RBLENBREgsT0FBaUIsd0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpzRGQsNkVBQUE7O0FBdXNEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRzRGQsNkVBQUE7O0FBNHNEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzc0RkLDZFQUFBOztBQWl0REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFodERkLDZFQUFBOztBQXN0REEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnREZCw2RUFBQTs7QUEydERBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXREZCw2RUFBQTs7QUFndURBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3REZCw2RUFBQTs7QUFxdURBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHVEZCw2RUFBQTs7QUEwdURBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp1RGQsNkVBQUE7O0FBK3VEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl1RGQsNkVBQUE7O0FBb3ZEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFudkRkLDZFQUFBOztBQXl2REEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4dkRkLDZFQUFBOztBQTh2REEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3ZEZCw2RUFBQTs7QUFtd0RBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHdEZCw2RUFBQTs7QUF3d0RBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ3RGQsNkVBQUE7O0FBNndEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTV3RGQsNkVBQUE7O0FBa3hEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWp4RGQsNkVBQUE7O0FBdXhEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXR4RGQsNkVBQUE7O0FBNHhEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN4RGQsNkVBQUE7O0FBaXlEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh5RGQsNkVBQUE7O0FBc3lEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyeURkLDZFQUFBOztBQTJ5REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExeURkLDZFQUFBOztBQWd6REEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3lEZCw2RUFBQTs7QUFxekRBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHpEZCw2RUFBQTs7QUEwekRBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenpEZCw2RUFBQTs7QUErekRBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXpEZCw2RUFBQTs7QUFvMERBLENBREgsT0FBaUIscUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW4wRGQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQ3VMSjtFQUNJLHNCQUFBOztBQUdKO0VBQ0ksVUFBQTtFQUNBLFNBQUE7RUFDQSw2QkFBQTtFQUNBLGVBQUE7O0FBRUEsa0JBQUM7RUFDRywyQkFBQTtFQUNBLG1CQUFBOztBTHhMSixtQkFBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBOztBQUVKLE9BQVE7RUFDSixPQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBS3lOUjtFQUNJLGNBQUE7RUh4TkEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGdCQUFBOztBQUNBLE9BQVE7RUFDSiw4QkFBQTs7QUd3TlI7RUFDSSxjQUFBO0VIdFBBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFR3NQQSxrQkFBQTtFQUNBLHVCQUFBOztBSHJQQSxnQkFBRTtBQUNGLGdCQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUNBLE9BQVEsaUJBZk47QUFlRixPQUFRLGlCQWROO0VBZUUsNkJBQUE7O0FBWEosZ0JBQUU7QUFDRixnQkFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxpQkE1Qk47QUE0QkYsT0FBUSxpQkEzQk47RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FHMlFSO0FBQ0E7RUFDSSwyQkFBQTs7QUFHSjtFQUNJLFdBQVcsY0FBWDs7QUFHSixxQkFBc0I7RUFDbEIsV0FBVyxTQUFYOztBQUdKLHFCQUFzQjtFQUNsQixXQUFXLGVBQVg7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBK0NKO0VBQ0ksY0FBQTs7QUw5VkEsa0JBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7QUs2VkosTUFBTTtFQUNGLFdBQUE7RUFDQSxnQkFBQTs7QUFJUjtFQUNJLHdCQUFBOztBQUdKO0VBQ0ksV0FBQTs7QUFHSjtFQUNJLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXFCSjtFQUNJLHNCQUFBO0VBQ0EsbUJBQUE7O0FBRUEsbUJBQUM7QUFDRCxtQkFBQztFQUNHLG1CQUFBOztBQU5SLG1CQVNJO0VBQ0ksb0JBQUE7O0FBVlIsbUJBY0k7RUFFSSxxQkFBQTs7QUFLQSxtQkFQSixvQkFPSztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1TVo7RUFDSSxzQkFBQTs7QUFHSjtFQUNJLGtDQUFBO0VBRUEsZ0NBQUE7RUFDQSxtQkFBQTtFQUNBLGNBQUE7RUhobUJBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQTJHQSxtQkFBQTtFQUNBLHlCQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBO0VHK2VBLGdCQUFBOztBSC9sQkEsT0FBUTtFQUNKLDhCQUFBOztBR2ltQlIsaUJBQWtCO0VBQ2QsZ0NBQUE7RUFDQSxnQkFBQTtFQUNBLG1CQUFBOztBQUdKLGlCQUFrQjtFSHBuQmQscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGdCQUFBO0VBMkdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSx1QkFBQTtFR3VnQkEsZ0JBQUE7O0FIbm5CQSxPQUFRLGtCR2luQk07RUhobkJWLDhCQUFBOztBR3FuQlIsaUJBQWtCO0VBQ2QsZ0JBQUEifQ== */
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1jc3Mvbm9ybWFsaXplLmNzcyIsIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1sZWdhY3ktYWRkb24vbm9ybWFsaXplLWxlZ2FjeS1hZGRvbi5jc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtdXRpbGl0aWVzLmxlc3MiLCIvc3JjL3ZlbmRvci9jZi1jb3JlL3NyYy9jZi11dGlsaXRpZXMubGVzcyIsIi8uLi9jZi1jb3JlL3NyYy9jZi1tZWRpYS1xdWVyaWVzLmxlc3MiLCIvc3JjL3ZlbmRvci9jZi1jb3JlL3NyYy9jZi1tZWRpYS1xdWVyaWVzLmxlc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtYmFzZS5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtY29yZS9zcmMvY2YtYmFzZS5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtY29yZS9zcmMvY2YtdmFycy5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtaWNvbnMvc3JjL2NmLWljb25zLmxlc3MiLCIvc3JjL2NmLWV4cGFuZGFibGVzLmxlc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7OztBQVFBO0VBQ0UsdUJBQUE7O0VBQ0EsMEJBQUE7O0VBQ0EsOEJBQUE7Ozs7OztBQU9GO0VBQ0UsU0FBQTs7Ozs7Ozs7OztBQWFGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7QUFDQTtBQUNBO0FBQ0E7RUFDRSxxQkFBQTs7RUFDQSx3QkFBQTs7Ozs7OztBQVFGLEtBQUssSUFBSTtFQUNQLGFBQUE7RUFDQSxTQUFBOzs7Ozs7QUFRRjtBQUNBO0VBQ0UsYUFBQTs7Ozs7OztBQVVGO0VBQ0UsNkJBQUE7Ozs7OztBQVFGLENBQUM7QUFDRCxDQUFDO0VBQ0MsVUFBQTs7Ozs7OztBQVVGLElBQUk7RUFDRix5QkFBQTs7Ozs7QUFPRjtBQUNBO0VBQ0UsaUJBQUE7Ozs7O0FBT0Y7RUFDRSxrQkFBQTs7Ozs7O0FBUUY7RUFDRSxjQUFBO0VBQ0EsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSxnQkFBQTtFQUNBLFdBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7RUFDRSxjQUFBO0VBQ0EsY0FBQTtFQUNBLGtCQUFBO0VBQ0Esd0JBQUE7O0FBR0Y7RUFDRSxXQUFBOztBQUdGO0VBQ0UsZUFBQTs7Ozs7OztBQVVGO0VBQ0UsU0FBQTs7Ozs7QUFPRixHQUFHLElBQUk7RUFDTCxnQkFBQTs7Ozs7OztBQVVGO0VBQ0UsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSx1QkFBQTtFQUNBLFNBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsaUNBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7OztBQWtCRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7RUFDQSxhQUFBOztFQUNBLFNBQUE7Ozs7OztBQU9GO0VBQ0UsaUJBQUE7Ozs7Ozs7O0FBVUY7QUFDQTtFQUNFLG9CQUFBOzs7Ozs7Ozs7QUFXRjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0gsMEJBQUE7O0VBQ0EsZUFBQTs7Ozs7O0FBT0YsTUFBTTtBQUNOLElBQUssTUFBSztFQUNSLGVBQUE7Ozs7O0FBT0YsTUFBTTtBQUNOLEtBQUs7RUFDSCxTQUFBO0VBQ0EsVUFBQTs7Ozs7O0FBUUY7RUFDRSxtQkFBQTs7Ozs7Ozs7O0FBV0YsS0FBSztBQUNMLEtBQUs7RUFDSCxzQkFBQTs7RUFDQSxVQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsWUFBQTs7Ozs7O0FBUUYsS0FBSztFQUNILDZCQUFBOztFQUNBLHVCQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsd0JBQUE7Ozs7O0FBT0Y7RUFDRSx5QkFBQTtFQUNBLGFBQUE7RUFDQSw4QkFBQTs7Ozs7O0FBUUY7RUFDRSxTQUFBOztFQUNBLFVBQUE7Ozs7OztBQU9GO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7RUFDRSxpQkFBQTs7Ozs7OztBQVVGO0VBQ0UseUJBQUE7RUFDQSxpQkFBQTs7QUFHRjtBQUNBO0VBQ0UsVUFBQTs7Ozs7Ozs7O0FDNVpGO0FBQ0E7QUFDQTtFQUNJLGdCQUFBO0VBQ0EsUUFBQTs7Ozs7Ozs7O0FBWUo7RUFDSSxlQUFBOzs7Ozs7QUFRSjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksdUJBQUE7Ozs7Ozs7Ozs7QUFhSjtFQUNJLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsYUFBQTs7QUFHSjtFQUNJLGNBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7Ozs7O0FBT0o7QUFDQTtFQUNJLGFBQUE7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSxjQUFjLHdCQUFkOzs7OztBQU9KO0VBQ0ksZ0JBQUE7RUFDQSxxQkFBQTs7Ozs7QUFPSjtFQUNJLFlBQUE7Ozs7O0FBT0osQ0FBQztBQUNELENBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxhQUFBOzs7Ozs7OztBQVdKO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtFQUNJLGtCQUFBOzs7OztBQU9KO0FBQ0E7QUFDQTtFQUNJLG1CQUFBOzs7OztBQU9KLEdBQUk7QUFDSixHQUFJO0VBQ0EsZ0JBQUE7RUFDQSxzQkFBQTs7Ozs7Ozs7QUFXSjtFQUNJLCtCQUFBOzs7Ozs7OztBQVdKO0VBQ0ksU0FBQTs7Ozs7OztBQVNKO0VBQ0ksU0FBQTs7RUFDQSxtQkFBQTs7RUFDQSxrQkFBQTs7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSx3QkFBQTtFQUNBLHVCQUFBOzs7Ozs7QUFRSjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0Qsa0JBQUE7Ozs7OztBQVFKLEtBQUs7QUFDTCxLQUFLO0VBQ0QsYUFBQTtFQUNBLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDOU1BLE1BQU87RUFDSCx3QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF5QkosV0FBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBOztBQUVKLE9BQVE7RUFDSixPQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMEJSO0VBQ0Usa0JBQUE7RUFDQSxVQUFBO0VBQ0EsV0FBQTtFQUNBLFNBQUE7RUFDQSxZQUFBO0VBQ0EsVUFBQTtFQUNBLGdCQUFBO0VBQ0EsTUFBTSxhQUFOOzs7Ozs7Ozs7Ozs7OztBQWlCRjtFQUNJLHFCQUFBOztBQUNBLE9BQVE7RUFFSixlQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXdCUjtFQUNJLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9DSjtFQUNJLHFCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFtSEo7RUNMSSxrQkFBQTtFQUNBLHNCQUFBO0VBQ0EsU0FBQTs7QURPSjtFQUNJLGtCQUFBO0VBQ0EsTUFBQTtFQUNBLE9BQUE7RUFDQSxXQUFBO0VBQ0EsWUFBQTs7QUFHSjtFQ2pCSSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsU0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QURvTko7RUFBVSx3QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsMEJBQUE7O0FBQ1Y7RUFBVSw2QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwRFY7RUFBYSxXQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxtQkFBQTs7QUFDYjtFQUFhLG1CQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRWpnQmIscUJBSDBDO0VBRzFDO0lGd2lCUSxhQUFBOzs7QUd4aUJSLHFCQUgwQztFQUcxQztJSHdpQlEsYUFBQTs7O0FBSVI7RUFDSSxhQUFBOztBRTdpQkoscUJBSDBDO0VBRzFDO0lGK2lCUSxjQUFBOzs7QUcvaUJSLHFCQUgwQztFQUcxQztJSCtpQlEsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFtRFI7RUNIRSxrQkFBQTs7QURPRjtFQ1BFLGtCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FHeGlCRjtFQUNJLGNBQUE7RUFDQSxzQkFBc0Isd0JBQXRCO0VBQ0EsZUFBQTtFQUNBLGtCQUFBOztBQThESjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDSSxhQUFBOztBQUdKO0FBQ0E7RUN4S0kscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBcUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURyR0EsRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRGxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEcUlKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7RUFDUCx3QkFBQTs7QUY5SVIscUJBSDBDO0VBRzFDO0VBQUE7SUdyQ0kscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBO0lBOEdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUQ5R0EsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRGxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbUpBLENBQUU7RUFBRixDQUFFO0VBQ0YsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsTUFBTztFQUFQLE1BQU87RUFDUCxHQUFJO0VBQUosR0FBSTtFQUNKLEtBQU07RUFBTixLQUFNO0VBQ04sVUFBVztFQUFYLFVBQVc7SUFDUCx3QkFBQTs7RUFHSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtJQUNBLHdCQUFBOzs7QUR6S1oscUJBSDBDO0VBRzFDO0VBQUE7SUVyQ0kscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBO0lBOEdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUQ5R0EsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRGxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbUpBLENBQUU7RUFBRixDQUFFO0VBQ0YsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsTUFBTztFQUFQLE1BQU87RUFDUCxHQUFJO0VBQUosR0FBSTtFQUNKLEtBQU07RUFBTixLQUFNO0VBQ04sVUFBVztFQUFYLFVBQVc7SUFDUCx3QkFBQTs7RUFHSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtJQUNBLHdCQUFBOzs7QUFLWjtBQUNBO0VDcE5JLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQThHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEOUdBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRGlMSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0VBQ1Asd0JBQUE7O0FBR0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUZ2TVIscUJBSDBDO0VBRzFDO0VBQUE7SUdyQ0kscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBO0lBdUhBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUR2SEEsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRGxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VENE1BLENBQUU7RUFBRixDQUFFO0VBQ0YsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsTUFBTztFQUFQLE1BQU87RUFDUCxHQUFJO0VBQUosR0FBSTtFQUNKLEtBQU07RUFBTixLQUFNO0VBQ04sVUFBVztFQUFYLFVBQVc7SUFDUCx3QkFBQTs7O0FEck5aLHFCQUgwQztFQUcxQztFQUFBO0lFckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQXVIQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEdkhBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRDRNQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7OztBQUtaO0FBQ0E7RUNoUUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBdUhBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUR2SEEsRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRGxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FENk5KLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBRmhQUixxQkFIMEM7RUFHMUM7RUFBQTtJR1pJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQXVHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEeEdBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RURESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBRlFSLHFCQUgwQztFQUcxQztFQUFBO0lFWkkscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGdCQUFBO0lBdUdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUR4R0EsT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFRERKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7O0FEZ1FSO0FBQ0E7RUNyUUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGdCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUR4R0EsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBRERKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURvUUosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztBQUNYLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FBSVI7QUFDQTtFQ3RSSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUF1R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsaUJBQUE7RUFDQSx5QkFBQTs7QUQxR0EsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBRERKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURxUkosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztBQUNYLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FBSVI7QUFDQTtFQ2hUSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUFrSEEscUJBQUE7RUFDQSxpQkFBQTtFQUNBLG1CQUFBO0VBQ0EsaUJBQUE7RUFDQSx5QkFBQTs7QURySEEsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBRERKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUQrU0osQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztBQUNYLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0EsaUJBQUE7O0FBSVI7QUFjQTtBQ0FBO0VBelhJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXVIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RURtUEEsd0JBQUE7RUFDQSwyQkFBQTs7QUEzV0EsZUFBRTtBQUNGLGVBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGdCRGZOO0FDZUYsT0FBUSxnQkRkTjtFQ2VFLDZCQUFBOztBRFhKLGVBQUU7QUFDRixlQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGdCQTVCTjtBQTRCRixPQUFRLGdCQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLGdCRDVCTjtBQzRCRixPQUFRLGdCRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osZUFBRTtBQUNGLGVBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxnQkNmTjtBRGVGLE9BQVEsZ0JDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLGdCQWZOO0FBZUYsT0FBUSxnQkFkTjtFQWVFLDZCQUFBOztBQVhKLGVBQUU7QUFDRixlQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGdCQzVCTjtBRDRCRixPQUFRLGdCQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGdCQTVCTjtBQTRCRixPQUFRLGdCQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osZUFBRTtBQUNGLGVBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGdCRGZOO0FDZUYsT0FBUSxnQkRkTjtFQ2VFLDZCQUFBOztBRFhKLGVBQUU7QUFDRixlQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGdCQTVCTjtBQTRCRixPQUFRLGdCQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLGdCRDVCTjtBQzRCRixPQUFRLGdCRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osZUFBRTtBQUNGLGVBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxnQkNmTjtBRGVGLE9BQVEsZ0JDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLGdCQWZOO0FBZUYsT0FBUSxnQkFkTjtFQWVFLDZCQUFBOztBQVhKLGVBQUU7QUFDRixlQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGdCQzVCTjtBRDRCRixPQUFRLGdCQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGdCQTVCTjtBQTRCRixPQUFRLGdCQTNCTjtFQTRCRSw4QkFBQTs7QUhEUixxQkFIMEM7RUFHMUM7RUVvVkE7RUNBQTtJRE5RLHdCQUFBO0lBQ0Esa0JBQUE7OztBRC9VUixxQkFIMEM7RUFHMUM7RUNvVkE7RUNBQTtJRE5RLHdCQUFBO0lBQ0Esa0JBQUE7OztBQVNSO0FBWUE7QUNBQTtFQXpZSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RURpWUEsMkJBQUE7RUFDQSxjQUFBO0VBQ0EsaUJBQUE7O0FBallBLGFBQUU7QUFDRixhQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsY0FmTjtBQWVGLE9BQVEsY0FkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsY0RmTjtBQ2VGLE9BQVEsY0RkTjtFQ2VFLDZCQUFBOztBRFhKLGFBQUU7QUFDRixhQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGNBNUJOO0FBNEJGLE9BQVEsY0EzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxjRDVCTjtBQzRCRixPQUFRLGNEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixhQUFFO0FBQ0YsYUFBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGNDZk47QURlRixPQUFRLGNDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLGNBZk47QUFlRixPQUFRLGNBZE47RUFlRSw2QkFBQTs7QUFYSixhQUFFO0FBQ0YsYUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxjQzVCTjtBRDRCRixPQUFRLGNDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsY0E1Qk47QUE0QkYsT0FBUSxjQTNCTjtFQTRCRSw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FEK1hSO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTtFQUNBLHVCQUFBOztBQUdKLENBQUU7QUFDRixDQUFFO0VBQ0UscUJBQUE7O0FBR0osSUFBSSxLQUFNO0VBQ04sb0JBQUE7O0FBSUosT0FBUSxJQUFJO0VBQ1IsZ0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQThCSjtFQUNJLGVBQUE7RUFDQSxvQkFBQTtFQUNBLHFCQUFBO0VBQ0EsY0FBQTtFQUNBLHFCQUFBOztBQUVBLENBQUM7QUFDRCxDQUFDO0VBQ0cscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7O0FBR0osQ0FBQztBQUNELENBQUM7RUFDRyxtQkFBQTtFQUNBLG9CQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNFUixDQUtJO0FBSkosRUFJSTtBQUhKLEVBR0k7RUFDSSx3QkFBQTs7QUFJUixHQUFJO0VBRUEsc0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE0Qko7RUFHSSxpQkFBQTtFQUNBLGtCQUFBOztBQUlKO0VBQ0ksc0JBQUE7O0FBREosRUFHSTtFQUNJLHNCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBeUNSO0VDMXBCSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FERUEsS0FBRTtBQUNGLEtBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxNRGZOO0FDZUYsT0FBUSxNRGROO0VDZUUsNkJBQUE7O0FEWEosS0FBRTtBQUNGLEtBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLE1ENUJOO0FDNEJGLE9BQVEsTUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEtBQUU7QUFDRixLQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUNmTjtBRGVGLE9BQVEsTUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQVhKLEtBQUU7QUFDRixLQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1DNUJOO0FENEJGLE9BQVEsTUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBRHduQlI7QUFDQTtFQUNJLGdCQUFBOztBQUVBLEtBQU07QUFBTixLQUFNO0VBQ0YsY0FBQTtFQUNBLG1CQUFBO0VDbG9CSixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUF1R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsaUJBQUE7RUFDQSx5QkFBQTs7QUQxR0EsT0FBUSxNQTZuQkY7QUE3bkJOLE9BQVEsTUE2bkJGO0VBNW5CRiw4QkFBQTs7QUNESixPQUFRLE1ENm5CRjtBQzduQk4sT0FBUSxNRDZuQkY7RUM1bkJGLDhCQUFBOztBRERKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FDREosT0FBUSxNRDZuQkY7QUM3bkJOLE9BQVEsTUQ2bkJGO0VDNW5CRiw4QkFBQTs7QURxUkosQ0FBRSxRQXVXSTtBQXZXTixDQUFFLFFBdVdJO0FBdFdOLEVBQUcsUUFzV0c7QUF0V04sRUFBRyxRQXNXRztBQXJXTixFQUFHLFFBcVdHO0FBcldOLEVBQUcsUUFxV0c7QUFwV04sRUFBRyxRQW9XRztBQXBXTixFQUFHLFFBb1dHO0FBbldOLE1BQU8sUUFtV0Q7QUFuV04sTUFBTyxRQW1XRDtBQWxXTixHQUFJLFFBa1dFO0FBbFdOLEdBQUksUUFrV0U7QUFqV04sS0FBTSxRQWlXQTtBQWpXTixLQUFNLFFBaVdBO0FBaFdOLFVBQVcsUUFnV0w7QUFoV04sVUFBVyxRQWdXTDtBQS9WTixFQUFHLFFBK1ZHO0FBL1ZOLEVBQUcsUUErVkc7QUE5Vk4sR0FBSSxRQThWRTtBQTlWTixHQUFJLFFBOFZFO0FBN1ZOLEVBQUcsUUE2Vkc7QUE3Vk4sRUFBRyxRQTZWRztBQTVWTixHQUFJLFFBNFZFO0FBNVZOLEdBQUksUUE0VkU7QUEzVk4sRUFBRyxRQTJWRztBQTNWTixFQUFHLFFBMlZHO0FBMVZOLEdBQUksUUEwVkU7QUExVk4sR0FBSSxRQTBWRTtBQXpWTixFQUFHLFFBeVZHO0FBelZOLEVBQUcsUUF5Vkc7QUF4Vk4sR0FBSSxRQXdWRTtBQXhWTixHQUFJLFFBd1ZFO0FBdlZOLEVBQUcsUUF1Vkc7QUF2Vk4sRUFBRyxRQXVWRztBQXRWTixHQUFJLFFBc1ZFO0FBdFZOLEdBQUksUUFzVkU7RUFyVkYsd0JBQUE7O0FBeFNKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FDREosT0FBUSxNRDZuQkY7QUM3bkJOLE9BQVEsTUQ2bkJGO0VDNW5CRiw4QkFBQTs7QURESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUQ2bkJGO0FDN25CTixPQUFRLE1ENm5CRjtFQzVuQkYsOEJBQUE7O0FBcVJKLENBQUUsUUR1V0k7QUN2V04sQ0FBRSxRRHVXSTtBQ3RXTixFQUFHLFFEc1dHO0FDdFdOLEVBQUcsUURzV0c7QUNyV04sRUFBRyxRRHFXRztBQ3JXTixFQUFHLFFEcVdHO0FDcFdOLEVBQUcsUURvV0c7QUNwV04sRUFBRyxRRG9XRztBQ25XTixNQUFPLFFEbVdEO0FDbldOLE1BQU8sUURtV0Q7QUNsV04sR0FBSSxRRGtXRTtBQ2xXTixHQUFJLFFEa1dFO0FDaldOLEtBQU0sUURpV0E7QUNqV04sS0FBTSxRRGlXQTtBQ2hXTixVQUFXLFFEZ1dMO0FDaFdOLFVBQVcsUURnV0w7QUMvVk4sRUFBRyxRRCtWRztBQy9WTixFQUFHLFFEK1ZHO0FDOVZOLEdBQUksUUQ4VkU7QUM5Vk4sR0FBSSxRRDhWRTtBQzdWTixFQUFHLFFENlZHO0FDN1ZOLEVBQUcsUUQ2Vkc7QUM1Vk4sR0FBSSxRRDRWRTtBQzVWTixHQUFJLFFENFZFO0FDM1ZOLEVBQUcsUUQyVkc7QUMzVk4sRUFBRyxRRDJWRztBQzFWTixHQUFJLFFEMFZFO0FDMVZOLEdBQUksUUQwVkU7QUN6Vk4sRUFBRyxRRHlWRztBQ3pWTixFQUFHLFFEeVZHO0FDeFZOLEdBQUksUUR3VkU7QUN4Vk4sR0FBSSxRRHdWRTtBQ3ZWTixFQUFHLFFEdVZHO0FDdlZOLEVBQUcsUUR1Vkc7QUN0Vk4sR0FBSSxRRHNWRTtBQ3RWTixHQUFJLFFEc1ZFO0VDclZGLHdCQUFBOztBRDRWUjtBQUNBLEtBQU07RUFDRixnQ0FBQTs7QUFHSjtFQzVvQkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VENG9CQSxnQkFBQTs7QUEzb0JBLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0VBQ0osOEJBQUE7O0FENm9CUixLQUFNO0VDbnJCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FERUEsS0ErcUJFLEdBL3FCQTtBQUNGLEtBOHFCRSxHQTlxQkE7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQWdxQk4sR0EvcUJBO0FBZUYsT0FBUSxNQWdxQk4sR0E5cUJBO0VBZUUsNkJBQUE7O0FDREosT0FBUSxNRGdxQk4sR0EvcUJBO0FDZUYsT0FBUSxNRGdxQk4sR0E5cUJBO0VDZUUsNkJBQUE7O0FEWEosS0EwcUJFLEdBMXFCQTtBQUNGLEtBeXFCRSxHQXpxQkE7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUE4b0JOLEdBMXFCQTtBQTRCRixPQUFRLE1BOG9CTixHQXpxQkE7RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDhvQk4sR0ExcUJBO0FDNEJGLE9BQVEsTUQ4b0JOLEdBenFCQTtFQzRCRSw4QkFBQTs7QUFsQ0osS0QrcUJFLEdDL3FCQTtBQUNGLEtEOHFCRSxHQzlxQkE7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQWdxQk4sR0MvcUJBO0FEZUYsT0FBUSxNQWdxQk4sR0M5cUJBO0VEZUUsNkJBQUE7O0FDREosT0FBUSxNRGdxQk4sR0MvcUJBO0FBZUYsT0FBUSxNRGdxQk4sR0M5cUJBO0VBZUUsNkJBQUE7O0FBWEosS0QwcUJFLEdDMXFCQTtBQUNGLEtEeXFCRSxHQ3pxQkE7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUE4b0JOLEdDMXFCQTtBRDRCRixPQUFRLE1BOG9CTixHQ3pxQkE7RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxNRDhvQk4sR0MxcUJBO0FBNEJGLE9BQVEsTUQ4b0JOLEdDenFCQTtFQTRCRSw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FEMnFCUjtFQUNJLHNCQUFBO0VBQ0EscUJBQUE7O0FGcnJCSixxQkFIMEM7RUFHMUM7SUV3ckJRLHFCQUFBO0lBQ0Esb0JBQUE7OztBRHpyQlIscUJBSDBDO0VBRzFDO0lDd3JCUSxxQkFBQTtJQUNBLG9CQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBNEJSO0VBQ0ksY0FBQTtFQUVBLHVCQUFBO0VDdHZCQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FERUEsS0FBRTtBQUNGLEtBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxNRGZOO0FDZUYsT0FBUSxNRGROO0VDZUUsNkJBQUE7O0FEWEosS0FBRTtBQUNGLEtBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLE1ENUJOO0FDNEJGLE9BQVEsTUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEtBQUU7QUFDRixLQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUNmTjtBRGVGLE9BQVEsTUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQVhKLEtBQUU7QUFDRixLQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1DNUJOO0FENEJGLE9BQVEsTUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBRDZzQlIsS0FNSSxNQUFLO0FBTlQsS0FPSSxNQUFLO0VBQ0QscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1RVIsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0w7QUFDQSxNQUFNO0VBR0YscUJBQUE7RUFDQSxTQUFBO0VBQ0EsZ0JBQUE7RUFDQSw4QkFBQTtFQUNBLGNBQUE7RUFDQSxtQkFBQTtFQUNBLHlCQUFBO0VBQ0EsZ0JBQUE7RUFDQSxtQkFBQTtFQUNBLHdCQUFBO0VBQ0EsOENBQUE7O0FBS0o7RUFDSSx3QkFBQTs7QUFLSixLQUFLLGFBQWE7QUFDbEIsS0FBSyxhQUFhO0FBQ2xCLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxjQUFjO0FBQ25CLEtBQUssY0FBYztBQUNuQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtBQUNwQixRQUFRO0FBQ1IsUUFBUTtBQUNSLE1BQU0sVUFBVTtBQUNoQixNQUFNLFVBQVU7RUFDWix5QkFBQTtFQUNBLDBCQUFBO0VBQ0EsaUJBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNHLE9FaDBCNkIsa0JGZzBCN0I7O0FBRUg7RUFDRyxPRW4wQjZCLGtCRm0wQjdCOztBQUVIO0VBQ0csT0V0MEI2QixrQkZzMEI3Qjs7Ozs7Ozs7Ozs7Ozs7QUFpQkg7RUFDSSxlQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBc0JKO0VBQ0ksY0FBQTtFQUNBLGVBQUE7O0FBRkosTUFJSTtFQUVJLHNCQUFBOztBQUlSLGlCQUFrQjtFQUNkLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FIMTdCQSxNQUFPO0VBQ0gsd0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBeUJKLFdBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBCUjtFQUNFLGtCQUFBO0VBQ0EsVUFBQTtFQUNBLFdBQUE7RUFDQSxTQUFBO0VBQ0EsWUFBQTtFQUNBLFVBQUE7RUFDQSxnQkFBQTtFQUNBLE1BQU0sYUFBTjs7Ozs7Ozs7Ozs7Ozs7QUFpQkY7RUFDSSxxQkFBQTs7QUFDQSxPQUFRO0VBRUosZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3QlI7RUFDSSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvQ0o7RUFDSSxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbUhKO0VBTEksa0JBQUE7RUFDQSxzQkFBQTtFQUNBLFNBQUE7O0FBT0o7RUFDSSxrQkFBQTtFQUNBLE1BQUE7RUFDQSxPQUFBO0VBQ0EsV0FBQTtFQUNBLFlBQUE7O0FBR0o7RUFqQkksa0JBQUE7RUFDQSxtQkFBQTtFQUNBLFNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb05KO0VBQVUsd0JBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDBCQUFBOztBQUNWO0VBQVUsNkJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMERWO0VBQWEsV0FBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsbUJBQUE7O0FBQ2I7RUFBYSxtQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUNqZ0JiLHFCQUgwQztFQUcxQztJRHdpQlEsYUFBQTs7O0FFeGlCUixxQkFIMEM7RUFHMUM7SUZ3aUJRLGFBQUE7OztBQUlSO0VBQ0ksYUFBQTs7QUM3aUJKLHFCQUgwQztFQUcxQztJRCtpQlEsY0FBQTs7O0FFL2lCUixxQkFIMEM7RUFHMUM7SUYraUJRLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbURSO0VBSEUsa0JBQUE7O0FBT0Y7RUFQRSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBSXhpQkY7RUFDSSxjQUFBO0VBQ0Esc0JBQXNCLHdCQUF0QjtFQUNBLGVBQUE7RUFDQSxrQkFBQTs7QUE4REo7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtBQUNBO0VBeEtJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEckdBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQXFJSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0VBQ1Asd0JBQUE7O0FIOUlSLHFCQUgwQztFQUcxQztFQUFBO0lHckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQThHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEOUdBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQW1KQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7O0VBR0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7SUFDQSx3QkFBQTs7O0FGektaLHFCQUgwQztFQUcxQztFQUFBO0lFckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQThHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEOUdBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQW1KQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7O0VBR0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7SUFDQSx3QkFBQTs7O0FBS1o7QUFDQTtFQXBOSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUE4R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRDlHQSxFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUFpTEosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztFQUNQLHdCQUFBOztBQUdKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FIdk1SLHFCQUgwQztFQUcxQztFQUFBO0lHckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQXVIQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEdkhBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQTRNQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7OztBRnJOWixxQkFIMEM7RUFHMUM7RUFBQTtJRXJDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUF1SEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHZIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUE0TUEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOzs7QUFLWjtBQUNBO0VBaFFJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXVIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEdkhBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQTZOSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUhoUFIscUJBSDBDO0VBRzFDO0VBQUE7SUdaSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUF1R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHhHQSxPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VEREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOzs7QUZRUixxQkFIMEM7RUFHMUM7RUFBQTtJRVpJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQXVHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEeEdBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RURESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBQWdRUjtBQUNBO0VBclFJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEeEdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBb1FKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBQUlSO0FBQ0E7RUF0UkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEMUdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBcVJKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBQUlSO0FBQ0E7RUFoVEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBa0hBLHFCQUFBO0VBQ0EsaUJBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEckhBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBK1NKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLGlCQUFBOztBQUlSO0FEY0E7QUNBQTtFQXpYSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUF1SEEsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBbVBBLHdCQUFBO0VBQ0EsMkJBQUE7O0FEM1dBLGVBQUU7QUFDRixlQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxnQkRmTjtBQ2VGLE9BQVEsZ0JEZE47RUNlRSw2QkFBQTs7QURYSixlQUFFO0FBQ0YsZUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxnQkQ1Qk47QUM0QkYsT0FBUSxnQkQzQk47RUM0QkUsOEJBQUE7O0FBbENKLGVBQUU7QUFDRixlQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JDZk47QURlRixPQUFRLGdCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUFYSixlQUFFO0FBQ0YsZUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkM1Qk47QUQ0QkYsT0FBUSxnQkMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FEbENKLGVBQUU7QUFDRixlQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxnQkRmTjtBQ2VGLE9BQVEsZ0JEZE47RUNlRSw2QkFBQTs7QURYSixlQUFFO0FBQ0YsZUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxnQkQ1Qk47QUM0QkYsT0FBUSxnQkQzQk47RUM0QkUsOEJBQUE7O0FBbENKLGVBQUU7QUFDRixlQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JDZk47QURlRixPQUFRLGdCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUFYSixlQUFFO0FBQ0YsZUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkM1Qk47QUQ0QkYsT0FBUSxnQkMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FIRFIscUJBSDBDO0VBRzFDO0VFb1ZBO0VDQUE7SUFOUSx3QkFBQTtJQUNBLGtCQUFBOzs7QUYvVVIscUJBSDBDO0VBRzFDO0VDb1ZBO0VDQUE7SUFOUSx3QkFBQTtJQUNBLGtCQUFBOzs7QUFTUjtBRFlBO0FDQUE7RUF6WUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBaVlBLDJCQUFBO0VBQ0EsY0FBQTtFQUNBLGlCQUFBOztBRGpZQSxhQUFFO0FBQ0YsYUFBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGNBZk47QUFlRixPQUFRLGNBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGNEZk47QUNlRixPQUFRLGNEZE47RUNlRSw2QkFBQTs7QURYSixhQUFFO0FBQ0YsYUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxjQTVCTjtBQTRCRixPQUFRLGNBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsY0Q1Qk47QUM0QkYsT0FBUSxjRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osYUFBRTtBQUNGLGFBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxjQ2ZOO0FEZUYsT0FBUSxjQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxjQWZOO0FBZUYsT0FBUSxjQWROO0VBZUUsNkJBQUE7O0FBWEosYUFBRTtBQUNGLGFBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsY0M1Qk47QUQ0QkYsT0FBUSxjQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGNBNUJOO0FBNEJGLE9BQVEsY0EzQk47RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQStYUjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNJLGFBQUE7RUFDQSx1QkFBQTs7QUFHSixDQUFFO0FBQ0YsQ0FBRTtFQUNFLHFCQUFBOztBQUdKLElBQUksS0FBTTtFQUNOLG9CQUFBOztBQUlKLE9BQVEsSUFBSTtFQUNSLGdCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE4Qko7RUFDSSxlQUFBO0VBQ0Esb0JBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7RUFDQSxxQkFBQTs7QUFFQSxDQUFDO0FBQ0QsQ0FBQztFQUNHLHFCQUFBO0VBQ0EsY0FBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxvQkFBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzRVIsQ0FLSTtBQUpKLEVBSUk7QUFISixFQUdJO0VBQ0ksd0JBQUE7O0FBSVIsR0FBSTtFQUVBLHNCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBNEJKO0VBR0ksaUJBQUE7RUFDQSxrQkFBQTs7QUFJSjtFQUNJLHNCQUFBOztBQURKLEVBR0k7RUFDSSxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXlDUjtFQTFwQkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBQUU7QUFDRixLQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURmTjtBQ2VGLE9BQVEsTURkTjtFQ2VFLDZCQUFBOztBRFhKLEtBQUU7QUFDRixLQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDVCTjtBQzRCRixPQUFRLE1EM0JOO0VDNEJFLDhCQUFBOztBQWxDSixLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZk47QURlRixPQUFRLE1DZE47RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzVCTjtBRDRCRixPQUFRLE1DM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUF3bkJSO0FBQ0E7RUFDSSxnQkFBQTs7QUFFQSxLQUFNO0FBQU4sS0FBTTtFQUNGLGNBQUE7RUFDQSxtQkFBQTtFQWxvQkoscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEMUdBLE9BQVEsTUM2bkJGO0FEN25CTixPQUFRLE1DNm5CRjtFRDVuQkYsOEJBQUE7O0FDREosT0FBUSxNQTZuQkY7QUE3bkJOLE9BQVEsTUE2bkJGO0VBNW5CRiw4QkFBQTs7QURESixPQUFRLE1DNm5CRjtBRDduQk4sT0FBUSxNQzZuQkY7RUQ1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FEcVJKLENBQUUsUUN1V0k7QUR2V04sQ0FBRSxRQ3VXSTtBRHRXTixFQUFHLFFDc1dHO0FEdFdOLEVBQUcsUUNzV0c7QURyV04sRUFBRyxRQ3FXRztBRHJXTixFQUFHLFFDcVdHO0FEcFdOLEVBQUcsUUNvV0c7QURwV04sRUFBRyxRQ29XRztBRG5XTixNQUFPLFFDbVdEO0FEbldOLE1BQU8sUUNtV0Q7QURsV04sR0FBSSxRQ2tXRTtBRGxXTixHQUFJLFFDa1dFO0FEaldOLEtBQU0sUUNpV0E7QURqV04sS0FBTSxRQ2lXQTtBRGhXTixVQUFXLFFDZ1dMO0FEaFdOLFVBQVcsUUNnV0w7QUQvVk4sRUFBRyxRQytWRztBRC9WTixFQUFHLFFDK1ZHO0FEOVZOLEdBQUksUUM4VkU7QUQ5Vk4sR0FBSSxRQzhWRTtBRDdWTixFQUFHLFFDNlZHO0FEN1ZOLEVBQUcsUUM2Vkc7QUQ1Vk4sR0FBSSxRQzRWRTtBRDVWTixHQUFJLFFDNFZFO0FEM1ZOLEVBQUcsUUMyVkc7QUQzVk4sRUFBRyxRQzJWRztBRDFWTixHQUFJLFFDMFZFO0FEMVZOLEdBQUksUUMwVkU7QUR6Vk4sRUFBRyxRQ3lWRztBRHpWTixFQUFHLFFDeVZHO0FEeFZOLEdBQUksUUN3VkU7QUR4Vk4sR0FBSSxRQ3dWRTtBRHZWTixFQUFHLFFDdVZHO0FEdlZOLEVBQUcsUUN1Vkc7QUR0Vk4sR0FBSSxRQ3NWRTtBRHRWTixHQUFJLFFDc1ZFO0VEclZGLHdCQUFBOztBQXhTSixPQUFRLE1DNm5CRjtBRDduQk4sT0FBUSxNQzZuQkY7RUQ1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FEREosT0FBUSxNQzZuQkY7QUQ3bkJOLE9BQVEsTUM2bkJGO0VENW5CRiw4QkFBQTs7QUNESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBQXFSSixDQUFFLFFBdVdJO0FBdldOLENBQUUsUUF1V0k7QUF0V04sRUFBRyxRQXNXRztBQXRXTixFQUFHLFFBc1dHO0FBcldOLEVBQUcsUUFxV0c7QUFyV04sRUFBRyxRQXFXRztBQXBXTixFQUFHLFFBb1dHO0FBcFdOLEVBQUcsUUFvV0c7QUFuV04sTUFBTyxRQW1XRDtBQW5XTixNQUFPLFFBbVdEO0FBbFdOLEdBQUksUUFrV0U7QUFsV04sR0FBSSxRQWtXRTtBQWpXTixLQUFNLFFBaVdBO0FBaldOLEtBQU0sUUFpV0E7QUFoV04sVUFBVyxRQWdXTDtBQWhXTixVQUFXLFFBZ1dMO0FBL1ZOLEVBQUcsUUErVkc7QUEvVk4sRUFBRyxRQStWRztBQTlWTixHQUFJLFFBOFZFO0FBOVZOLEdBQUksUUE4VkU7QUE3Vk4sRUFBRyxRQTZWRztBQTdWTixFQUFHLFFBNlZHO0FBNVZOLEdBQUksUUE0VkU7QUE1Vk4sR0FBSSxRQTRWRTtBQTNWTixFQUFHLFFBMlZHO0FBM1ZOLEVBQUcsUUEyVkc7QUExVk4sR0FBSSxRQTBWRTtBQTFWTixHQUFJLFFBMFZFO0FBelZOLEVBQUcsUUF5Vkc7QUF6Vk4sRUFBRyxRQXlWRztBQXhWTixHQUFJLFFBd1ZFO0FBeFZOLEdBQUksUUF3VkU7QUF2Vk4sRUFBRyxRQXVWRztBQXZWTixFQUFHLFFBdVZHO0FBdFZOLEdBQUksUUFzVkU7QUF0Vk4sR0FBSSxRQXNWRTtFQXJWRix3QkFBQTs7QUE0VlI7QUFDQSxLQUFNO0VBQ0YsZ0NBQUE7O0FBR0o7RUE1b0JJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQTRvQkEsZ0JBQUE7O0FEM29CQSxPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtFQUNKLDhCQUFBOztBQTZvQlIsS0FBTTtFQW5yQkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtDK3FCRSxHRC9xQkE7QUFDRixLQzhxQkUsR0Q5cUJBO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUNncUJOLEdEL3FCQTtBQWVGLE9BQVEsTUNncUJOLEdEOXFCQTtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTUFncUJOLEdEL3FCQTtBQ2VGLE9BQVEsTUFncUJOLEdEOXFCQTtFQ2VFLDZCQUFBOztBRFhKLEtDMHFCRSxHRDFxQkE7QUFDRixLQ3lxQkUsR0R6cUJBO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1DOG9CTixHRDFxQkE7QUE0QkYsT0FBUSxNQzhvQk4sR0R6cUJBO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE4b0JOLEdEMXFCQTtBQzRCRixPQUFRLE1BOG9CTixHRHpxQkE7RUM0QkUsOEJBQUE7O0FBbENKLEtBK3FCRSxHQS9xQkE7QUFDRixLQThxQkUsR0E5cUJBO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUNncUJOLEdBL3FCQTtBRGVGLE9BQVEsTUNncUJOLEdBOXFCQTtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsTUFncUJOLEdBL3FCQTtBQWVGLE9BQVEsTUFncUJOLEdBOXFCQTtFQWVFLDZCQUFBOztBQVhKLEtBMHFCRSxHQTFxQkE7QUFDRixLQXlxQkUsR0F6cUJBO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1DOG9CTixHQTFxQkE7QUQ0QkYsT0FBUSxNQzhvQk4sR0F6cUJBO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE4b0JOLEdBMXFCQTtBQTRCRixPQUFRLE1BOG9CTixHQXpxQkE7RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTJxQlI7RUFDSSxzQkFBQTtFQUNBLHFCQUFBOztBSHJyQkoscUJBSDBDO0VBRzFDO0lHd3JCUSxxQkFBQTtJQUNBLG9CQUFBOzs7QUZ6ckJSLHFCQUgwQztFQUcxQztJRXdyQlEscUJBQUE7SUFDQSxvQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTRCUjtFQUNJLGNBQUE7RUFFQSx1QkFBQTtFQXR2QkEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBQUU7QUFDRixLQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURmTjtBQ2VGLE9BQVEsTURkTjtFQ2VFLDZCQUFBOztBRFhKLEtBQUU7QUFDRixLQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDVCTjtBQzRCRixPQUFRLE1EM0JOO0VDNEJFLDhCQUFBOztBQWxDSixLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZk47QURlRixPQUFRLE1DZE47RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzVCTjtBRDRCRixPQUFRLE1DM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUE2c0JSLEtBTUksTUFBSztBQU5ULEtBT0ksTUFBSztFQUNELHFCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdUVSLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMO0FBQ0EsTUFBTTtFQUdGLHFCQUFBO0VBQ0EsU0FBQTtFQUNBLGdCQUFBO0VBQ0EsOEJBQUE7RUFDQSxjQUFBO0VBQ0EsbUJBQUE7RUFDQSx5QkFBQTtFQUNBLGdCQUFBO0VBQ0EsbUJBQUE7RUFDQSx3QkFBQTtFQUNBLDhDQUFBOztBQUtKO0VBQ0ksd0JBQUE7O0FBS0osS0FBSyxhQUFhO0FBQ2xCLEtBQUssYUFBYTtBQUNsQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssY0FBYztBQUNuQixLQUFLLGNBQWM7QUFDbkIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7QUFDcEIsUUFBUTtBQUNSLFFBQVE7QUFDUixNQUFNLFVBQVU7QUFDaEIsTUFBTSxVQUFVO0VBQ1oseUJBQUE7RUFDQSwwQkFBQTtFQUNBLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDRyxPQ2gwQjZCLGtCRGcwQjdCOztBQUVIO0VBQ0csT0NuMEI2QixrQkRtMEI3Qjs7QUFFSDtFQUNHLE9DdDBCNkIsa0JEczBCN0I7Ozs7Ozs7Ozs7Ozs7O0FBaUJIO0VBQ0ksZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNCSjtFQUNJLGNBQUE7RUFDQSxlQUFBOztBQUZKLE1BSUk7RUFFSSxzQkFBQTs7QUFJUixpQkFBa0I7RUFDZCx5QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FFbjVCSjtFQUNFLGFBQWEsZUFBYjtFQUNBLFNBQVMsd0JBQVQ7RUFDQSxTQUFTLGdDQUF1QyxPQUFPLDBCQUNqRCwwQkFBaUMsT0FBTyxhQUN4Qyx5QkFBZ0MsT0FBTyxpQkFDdkMseUJBQWdDLE9BQU8sTUFIN0M7RUFJQSxtQkFBQTtFQUNBLGtCQUFBOztBQWdCRjtBQUNBLENBQUM7RUFDQyxhQUFhLGVBQWI7RUFDQSxxQkFBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxjQUFBO0VBQ0EsbUNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb1FGLENBQUMsT0FBaUI7RUFDaEIsdUJBQUE7RUFDQSxtQkFBQTtFQUNBLG9CQUFBOztBQUdGLENBQUMsT0FBaUI7RUFBTyxjQUFBOztBQUN6QixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7QUFDekIsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7O0FBQ3pCLENBQUMsT0FBaUI7RUFBTyxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTZEekIsQ0FBQyxPQUFpQjtFQUNoQix5QkFBQTtFQUNBLDRCQUFBO0VBQ0EsbUJBQUE7O0FBR0YsQ0FBQyxPQUFpQjtFQXpDaEIsUUFBUSx3REFBUjtFQUNBLG1CQUFtQixhQUFuQjtFQUNJLGVBQWUsYUFBZjtFQUNJLFdBQVcsYUFBWDs7QUF1Q1YsQ0FBQyxPQUFpQjtFQTFDaEIsUUFBUSx3REFBUjtFQUNBLG1CQUFtQixjQUFuQjtFQUNJLGVBQWUsY0FBZjtFQUNJLFdBQVcsY0FBWDs7QUF3Q1YsQ0FBQyxPQUFpQjtFQTNDaEIsUUFBUSx3REFBUjtFQUNBLG1CQUFtQixjQUFuQjtFQUNJLGVBQWUsY0FBZjtFQUNJLFdBQVcsY0FBWDs7QUEwQ1YsQ0FBQyxPQUFpQjtFQXRDaEIsUUFBUSxrRUFBUjtFQUNBLG1CQUFtQixZQUFuQjtFQUNJLGVBQWUsWUFBZjtFQUNJLFdBQVcsWUFBWDs7QUFvQ1YsQ0FBQyxPQUFpQjtFQXZDaEIsUUFBUSxrRUFBUjtFQUNBLG1CQUFtQixZQUFuQjtFQUNJLGVBQWUsWUFBZjtFQUNJLFdBQVcsWUFBWDs7QUFzQ1YsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtFQUN0QixZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBc0JGLENBQUMsT0FBaUI7RUFDaEIsNkNBQUE7RUFDUSxxQ0FBQTs7QUFHVixDQUFDLE9BQWlCO0VBQ2hCLHVDQUF1QyxRQUF2QztFQUNRLCtCQUErQixRQUEvQjs7QUFHVjtFQUNFO0lBQ0UsbUJBQW1CLFlBQW5CO0lBQ1EsV0FBVyxZQUFYOztFQUVWO0lBQ0UsbUJBQW1CLGNBQW5CO0lBQ1EsV0FBVyxjQUFYOzs7QUFJWjtFQUNFO0lBQ0UsbUJBQW1CLFlBQW5CO0lBQ1EsV0FBVyxZQUFYOztFQUVWO0lBQ0UsbUJBQW1CLGNBQW5CO0lBQ1EsV0FBVyxjQUFYOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE4Q1IsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsZmQsNkVBQUE7O0FBd2ZBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdmZkLDZFQUFBOztBQTZmQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVmZCw2RUFBQTs7QUFrZ0JBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamdCZCw2RUFBQTs7QUF1Z0JBLENBREgsT0FBaUIsR0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdGdCZCw2RUFBQTs7QUE0Z0JBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM2dCZCw2RUFBQTs7QUFpaEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaGhCZCw2RUFBQTs7QUFzaEJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcmhCZCw2RUFBQTs7QUEyaEJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMWhCZCw2RUFBQTs7QUFnaUJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9oQmQsNkVBQUE7O0FBcWlCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBpQmQsNkVBQUE7O0FBMGlCQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6aUJkLDZFQUFBOztBQStpQkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5aUJkLDZFQUFBOztBQW9qQkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuakJkLDZFQUFBOztBQXlqQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4akJkLDZFQUFBOztBQThqQkEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN2pCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXdtQkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2bUJkLDZFQUFBOztBQTZtQkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1bUJkLDZFQUFBOztBQWtuQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqbkJkLDZFQUFBOztBQXVuQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0bkJkLDZFQUFBOztBQTRuQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzbkJkLDZFQUFBOztBQWlvQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFob0JkLDZFQUFBOztBQXNvQkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyb0JkLDZFQUFBOztBQTJvQkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExb0JkLDZFQUFBOztBQWdwQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvb0JkLDZFQUFBOztBQXFwQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwcEJkLDZFQUFBOztBQTBwQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6cEJkLDZFQUFBOztBQStwQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5cEJkLDZFQUFBOztBQW9xQkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucUJkLDZFQUFBOztBQXlxQkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cUJkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbXRCQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWx0QmQsNkVBQUE7O0FBd3RCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ0QmQsNkVBQUE7O0FBNnRCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTV0QmQsNkVBQUE7O0FBa3VCQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqdUJkLDZFQUFBOztBQXV1QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0dUJkLDZFQUFBOztBQTR1QkEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3VCZCw2RUFBQTs7QUFpdkJBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHZCZCw2RUFBQTs7QUFzdkJBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnZCZCw2RUFBQTs7QUEydkJBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXZCZCw2RUFBQTs7QUFnd0JBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3ZCZCw2RUFBQTs7QUFxd0JBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHdCZCw2RUFBQTs7QUEwd0JBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBendCZCw2RUFBQTs7QUErd0JBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXdCZCw2RUFBQTs7QUFveEJBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW54QmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTB6QkEsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6ekJkLDZFQUFBOztBQSt6QkEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5ekJkLDZFQUFBOztBQW8wQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuMEJkLDZFQUFBOztBQXkwQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4MEJkLDZFQUFBOztBQTgwQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3MEJkLDZFQUFBOztBQW0xQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsMUJkLDZFQUFBOztBQXcxQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2MUJkLDZFQUFBOztBQTYxQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1MUJkLDZFQUFBOztBQWsyQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqMkJkLDZFQUFBOztBQXUyQkEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdDJCZCw2RUFBQTs7QUE0MkJBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMzJCZCw2RUFBQTs7QUFpM0JBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaDNCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBKzZCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTk2QmQsNkVBQUE7O0FBbzdCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW43QmQsNkVBQUE7O0FBeTdCQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXg3QmQsNkVBQUE7O0FBODdCQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTc3QmQsNkVBQUE7O0FBbThCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWw4QmQsNkVBQUE7O0FBdzhCQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXY4QmQsNkVBQUE7O0FBNjhCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTU4QmQsNkVBQUE7O0FBazlCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWo5QmQsNkVBQUE7O0FBdTlCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXQ5QmQsNkVBQUE7O0FBNDlCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTM5QmQsNkVBQUE7O0FBaStCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgrQmQsNkVBQUE7O0FBcytCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXIrQmQsNkVBQUE7O0FBMitCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTErQmQsNkVBQUE7O0FBZy9CQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS8rQmQsNkVBQUE7O0FBcS9CQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXAvQmQsNkVBQUE7O0FBMC9CQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXovQmQsNkVBQUE7O0FBKy9CQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTkvQmQsNkVBQUE7O0FBb2dDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5nQ2QsNkVBQUE7O0FBeWdDQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhnQ2QsNkVBQUE7O0FBOGdDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdnQ2QsNkVBQUE7O0FBbWhDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxoQ2QsNkVBQUE7O0FBd2hDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2aENkLDZFQUFBOztBQTZoQ0EsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1aENkLDZFQUFBOztBQWtpQ0EsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqaUNkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWdvQ0EsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvbkNkLDZFQUFBOztBQXFvQ0EsQ0FESCxPQUFpQixtQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcG9DZCw2RUFBQTs7QUEwb0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBem9DZCw2RUFBQTs7QUErb0NBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlvQ2QsNkVBQUE7O0FBb3BDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5wQ2QsNkVBQUE7O0FBeXBDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhwQ2QsNkVBQUE7O0FBOHBDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdwQ2QsNkVBQUE7O0FBbXFDQSxDQURILE9BQWlCLHFCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFscUNkLDZFQUFBOztBQXdxQ0EsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2cUNkLDZFQUFBOztBQTZxQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1cUNkLDZFQUFBOztBQWtyQ0EsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanJDZCw2RUFBQTs7QUF1ckNBLENBREgsT0FBaUIsc0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRyQ2QsNkVBQUE7O0FBNHJDQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNyQ2QsNkVBQUE7O0FBaXNDQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoc0NkLDZFQUFBOztBQXNzQ0EsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyc0NkLDZFQUFBOztBQTJzQ0EsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExc0NkLDZFQUFBOztBQWd0Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvc0NkLDZFQUFBOztBQXF0Q0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHRDZCw2RUFBQTs7QUEwdENBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenRDZCw2RUFBQTs7QUErdENBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXRDZCw2RUFBQTs7QUFvdUNBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnVDZCw2RUFBQTs7QUF5dUNBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXh1Q2QsNkVBQUE7O0FBOHVDQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3dUNkLDZFQUFBOztBQW12Q0EsQ0FESCxPQUFpQiwwQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHZDZCw2RUFBQTs7QUF3dkNBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnZDZCw2RUFBQTs7QUE2dkNBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTV2Q2QsNkVBQUE7O0FBa3dDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWp3Q2QsNkVBQUE7O0FBdXdDQSxDQURILE9BQWlCLHFCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0d0NkLDZFQUFBOztBQTR3Q0EsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzd0NkLDZFQUFBOztBQWl4Q0EsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHhDZCw2RUFBQTs7QUFzeENBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnhDZCw2RUFBQTs7QUEyeENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXhDZCw2RUFBQTs7QUFneUNBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS94Q2QsNkVBQUE7O0FBcXlDQSxDQURILE9BQWlCLHNCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFweUNkLDZFQUFBOztBQTB5Q0EsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6eUNkLDZFQUFBOztBQSt5Q0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXlDZCw2RUFBQTs7QUFvekNBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnpDZCw2RUFBQTs7QUF5ekNBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXh6Q2QsNkVBQUE7O0FBOHpDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTd6Q2QsNkVBQUE7O0FBbTBDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsMENkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFpK0NBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaCtDZCw2RUFBQTs7QUFzK0NBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcitDZCw2RUFBQTs7QUEyK0NBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMStDZCw2RUFBQTs7QUFnL0NBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBLytDZCw2RUFBQTs7QUFxL0NBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcC9DZCw2RUFBQTs7QUEwL0NBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBei9DZCw2RUFBQTs7QUErL0NBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOS9DZCw2RUFBQTs7QUFvZ0RBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmdEZCw2RUFBQTs7QUF5Z0RBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGdEZCw2RUFBQTs7QUE4Z0RBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN2dEZCw2RUFBQTs7QUFtaERBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbGhEZCw2RUFBQTs7QUF3aERBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZoRGQsNkVBQUE7O0FBNmhEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVoRGQsNkVBQUE7O0FBa2lEQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqaURkLDZFQUFBOztBQXVpREEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0aURkLDZFQUFBOztBQTRpREEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM2lEZCw2RUFBQTs7QUFpakRBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaGpEZCw2RUFBQTs7QUFzakRBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJqRGQsNkVBQUE7O0FBMmpEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFqRGQsNkVBQUE7O0FBZ2tEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvakRkLDZFQUFBOztBQXFrREEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwa0RkLDZFQUFBOztBQTBrREEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6a0RkLDZFQUFBOztBQStrREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5a0RkLDZFQUFBOztBQW9sREEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmxEZCw2RUFBQTs7QUF5bERBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGxEZCw2RUFBQTs7QUE4bERBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN2xEZCw2RUFBQTs7QUFtbURBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbG1EZCw2RUFBQTs7QUF3bURBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZtRGQsNkVBQUE7O0FBNm1EQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVtRGQsNkVBQUE7O0FBa25EQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpuRGQsNkVBQUE7O0FBdW5EQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRuRGQsNkVBQUE7O0FBNG5EQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNuRGQsNkVBQUE7O0FBaW9EQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhvRGQsNkVBQUE7O0FBc29EQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJvRGQsNkVBQUE7O0FBMm9EQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFvRGQsNkVBQUE7O0FBZ3BEQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9vRGQsNkVBQUE7O0FBcXBEQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBwRGQsNkVBQUE7O0FBMHBEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXpwRGQsNkVBQUE7O0FBK3BEQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlwRGQsNkVBQUE7O0FBb3FEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5xRGQsNkVBQUE7O0FBeXFEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhxRGQsNkVBQUE7O0FBOHFEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdxRGQsNkVBQUE7O0FBbXJEQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxyRGQsNkVBQUE7O0FBd3JEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZyRGQsNkVBQUE7O0FBNnJEQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1ckRkLDZFQUFBOztBQWtzREEsQ0FESCxPQUFpQix3QkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanNEZCw2RUFBQTs7QUF1c0RBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHNEZCw2RUFBQTs7QUE0c0RBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNzRGQsNkVBQUE7O0FBaXREQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh0RGQsNkVBQUE7O0FBc3REQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFydERkLDZFQUFBOztBQTJ0REEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExdERkLDZFQUFBOztBQWd1REEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvdERkLDZFQUFBOztBQXF1REEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwdURkLDZFQUFBOztBQTB1REEsQ0FESCxPQUFpQixtQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenVEZCw2RUFBQTs7QUErdURBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXVEZCw2RUFBQTs7QUFvdkRBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW52RGQsNkVBQUE7O0FBeXZEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXh2RGQsNkVBQUE7O0FBOHZEQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3dkRkLDZFQUFBOztBQW13REEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsd0RkLDZFQUFBOztBQXd3REEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdndEZCw2RUFBQTs7QUE2d0RBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXdEZCw2RUFBQTs7QUFreERBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanhEZCw2RUFBQTs7QUF1eERBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHhEZCw2RUFBQTs7QUE0eERBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3hEZCw2RUFBQTs7QUFpeURBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHlEZCw2RUFBQTs7QUFzeURBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ5RGQsNkVBQUE7O0FBMnlEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF5RGQsNkVBQUE7O0FBZ3pEQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEveURkLDZFQUFBOztBQXF6REEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwekRkLDZFQUFBOztBQTB6REEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6ekRkLDZFQUFBOztBQSt6REEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5ekRkLDZFQUFBOztBQW8wREEsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbjBEZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDeUxKO0VBQ0ksc0JBQUE7O0FBR0o7RUFDSSxVQUFBO0VBQ0EsU0FBQTtFQUNBLDZCQUFBO0VBQ0EsZUFBQTs7QUFFQSxrQkFBQztFQUNHLDJCQUFBO0VBQ0EsbUJBQUE7O0FSMUxKLG1CQUFDO0VBQ0csU0FBUyxFQUFUO0VBQ0EsY0FBQTtFQUNBLFdBQUE7O0FBRUosT0FBUTtFQUNKLE9BQUE7O0FDTkosbUJBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QU8yTlI7RUFDSSxjQUFBO0VIMU5BLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTs7QURDQSxPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtFQUNKLDhCQUFBOztBRzBOUjtFQUNJLGNBQUE7RUh4UEEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VHd1BBLGtCQUFBO0VBQ0EsdUJBQUE7O0FKdlBBLGdCQUFFO0FBQ0YsZ0JBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxpQkFmTjtBQWVGLE9BQVEsaUJBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGlCRGZOO0FDZUYsT0FBUSxpQkRkTjtFQ2VFLDZCQUFBOztBRFhKLGdCQUFFO0FBQ0YsZ0JBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsaUJBNUJOO0FBNEJGLE9BQVEsaUJBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsaUJENUJOO0FDNEJGLE9BQVEsaUJEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixnQkFBRTtBQUNGLGdCQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsaUJDZk47QURlRixPQUFRLGlCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxpQkFmTjtBQWVGLE9BQVEsaUJBZE47RUFlRSw2QkFBQTs7QUFYSixnQkFBRTtBQUNGLGdCQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGlCQzVCTjtBRDRCRixPQUFRLGlCQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGlCQTVCTjtBQTRCRixPQUFRLGlCQTNCTjtFQTRCRSw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUc2UVI7QUFDQTtFQUNJLDJCQUFBOztBQUdKO0VBQ0ksV0FBVyxjQUFYOztBQUdKLHFCQUFzQjtFQUNsQixXQUFXLFNBQVg7O0FBR0oscUJBQXNCO0VBQ2xCLFdBQVcsZUFBWDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErQ0o7RUFDSSxjQUFBOztBUmhXQSxrQkFBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBOztBQUVKLE9BQVE7RUFDSixPQUFBOztBQ05KLGtCQUFDO0VBQ0csU0FBUyxFQUFUO0VBQ0EsY0FBQTtFQUNBLFdBQUE7O0FBRUosT0FBUTtFQUNKLE9BQUE7O0FPK1ZKLE1BQU07RUFDRixXQUFBO0VBQ0EsZ0JBQUE7O0FBSVI7RUFDSSx3QkFBQTs7QUFHSjtFQUNJLFdBQUE7O0FBR0o7RUFDSSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFxQko7RUFDSSxzQkFBQTtFQUNBLG1CQUFBOztBQUVBLG1CQUFDO0FBQ0QsbUJBQUM7RUFDRyxtQkFBQTs7QUFOUixtQkFTSTtFQUNJLG9CQUFBOztBQVZSLG1CQWNJO0VBRUkscUJBQUE7O0FBS0EsbUJBUEosb0JBT0s7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdU1aO0VBQ0ksc0JBQUE7O0FBR0o7RUFDSSxrQ0FBQTtFQUVBLGdDQUFBO0VBQ0EsbUJBQUE7RUFDQSxjQUFBO0VIbG1CQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUF1R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsaUJBQUE7RUFDQSx5QkFBQTtFR3VmQSxnQkFBQTs7QUpqbUJBLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0VBQ0osOEJBQUE7O0FEREosT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7RUFDSiw4QkFBQTs7QUdtbUJSLGlCQUFrQjtFQUNkLGdDQUFBO0VBQ0EsZ0JBQUE7RUFDQSxtQkFBQTs7QUFHSixpQkFBa0I7RUh0bkJkLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUc2Z0JBLGdCQUFBOztBSnJuQkEsT0FBUSxrQkltbkJNO0VKbG5CViw4QkFBQTs7QUNESixPQUFRLGtCR21uQk07RUhsbkJWLDhCQUFBOztBRERKLE9BQVEsa0JJbW5CTTtFSmxuQlYsOEJBQUE7O0FDREosT0FBUSxrQkdtbkJNO0VIbG5CViw4QkFBQTs7QUd1bkJSLGlCQUFrQjtFQUNkLGdCQUFBIn0= */

--- a/docs/static/css/main.css
+++ b/docs/static/css/main.css
@@ -765,13 +765,13 @@ input[type="radio"] {
 */
 .u-visually-hidden {
   position: absolute;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  height: 1px;
   width: 1px;
+  height: 1px;
+  border: 0;
   margin: -1px;
   padding: 0;
-  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
 }
 /* topdoc
   name: Inline block
@@ -1232,8 +1232,18 @@ input[type="radio"] {
     display: none;
   }
 }
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
 .u-show-on-mobile {
   display: none;
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
 }
 @media only all and (max-width: 37.5em) {
   .u-show-on-mobile {
@@ -1337,19 +1347,19 @@ small {
         <h1>Example heading element</h1>
         <p class="h1">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h2.
+        - Responsive heading. At small screen sizes, displays as h2.
     - name: Heading level 2
       markup: |
         <h2>Example heading element</h2>
         <p class="h2">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h3.
+        - Responsive heading. At small screen sizes, displays as h3.
     - name: Heading level 3
       markup: |
         <h3>Example heading element</h3>
         <p class="h3">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h4.
+        - Responsive heading. At small screen sizes, displays as h4.
     - name: Heading level 4
       markup: |
         <h4>Example heading element</h4>
@@ -1362,14 +1372,14 @@ small {
       markup: |
         <h6>Example heading element</h6>
         <p class="h6">A non-heading element</p>
-    - name: Subheader
+    - name: Lead paragraph
       markup: |
-        <h1 class="subheader">Example subheader that's kinda long</h1>
-        <p class="subheader">Example subheader that's kinda long</p>
-    - name: Super header
+        <p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      notes:
+        - Responsive. Displays as an h3 on large screens; displays at h4 size (but still Regular weight) on small screens.
+    - name: Display heading (aka "superheading")
       markup: |
-        <h1 class="superheader">Example super header</h1>
-        <p class="superheader">Example super header</p>
+        <h1 class="superheading">Example display heading</h1>
   tags:
     - cf-core
 */
@@ -1392,9 +1402,9 @@ h1,
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
-  margin-bottom: 0.47058824em;
+  margin-bottom: 0.44117647em;
   font-size: 2.125em;
-  line-height: 1.29411765;
+  line-height: 1.25;
 }
 h1 em,
 .h1 em,
@@ -1403,6 +1413,12 @@ h1 i,
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
 }
 .lt-ie9 h1 em,
 .lt-ie9 .h1 em,
@@ -1424,15 +1440,159 @@ h1 b,
 .lt-ie9 .h1 b {
   font-weight: normal !important;
 }
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+p + h1,
+p + .h1,
+ul + h1,
+ul + .h1,
+ol + h1,
+ol + .h1,
+dl + h1,
+dl + .h1,
+figure + h1,
+figure + .h1,
+img + h1,
+img + .h1,
+table + h1,
+table + .h1,
+blockquote + h1,
+blockquote + .h1 {
+  margin-top: 1.76470588em;
+}
 @media only all and (max-width: 37.5em) {
   h1,
   .h1 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
-    margin-bottom: 0.73076923em;
+    margin-bottom: 0.57692308em;
     font-size: 1.625em;
-    line-height: 1.26923077;
+    line-height: 1.25;
   }
   h1 em,
   .h1 em,
@@ -1441,6 +1601,12 @@ h1 b,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
   }
   .lt-ie9 h1 em,
   .lt-ie9 .h1 em,
@@ -1462,15 +1628,392 @@ h1 b,
   .lt-ie9 .h1 b {
     font-weight: normal !important;
   }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
 }
 h2,
 .h2 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
-  margin-bottom: 0.73076923em;
+  margin-bottom: 0.57692308em;
   font-size: 1.625em;
-  line-height: 1.26923077;
+  line-height: 1.25;
 }
 h2 em,
 .h2 em,
@@ -1479,6 +2022,12 @@ h2 i,
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
 }
 .lt-ie9 h2 em,
 .lt-ie9 .h2 em,
@@ -1500,15 +2049,181 @@ h2 b,
 .lt-ie9 .h2 b {
   font-weight: normal !important;
 }
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+p + h2,
+p + .h2,
+ul + h2,
+ul + .h2,
+ol + h2,
+ol + .h2,
+dl + h2,
+dl + .h2,
+figure + h2,
+figure + .h2,
+img + h2,
+img + .h2,
+table + h2,
+table + .h2,
+blockquote + h2,
+blockquote + .h2 {
+  margin-top: 1.73076923em;
+}
+h1 + h2,
+h1 + .h2,
+.h1 + h2,
+.h1 + .h2,
+h3 + h2,
+h3 + .h2,
+.h3 + h2,
+.h3 + .h2,
+h4 + h2,
+h4 + .h2,
+.h4 + h2,
+.h4 + .h2,
+h5 + h2,
+h5 + .h2,
+.h5 + h2,
+.h5 + .h2,
+h6 + h2,
+h6 + .h2,
+.h6 + h2,
+.h6 + .h2 {
+  margin-top: 1.15384615em;
+}
 @media only all and (max-width: 37.5em) {
   h2,
   .h2 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
-    margin-bottom: 0.95454545em;
+    margin-bottom: 0.68181818em;
     font-size: 1.375em;
-    line-height: 1.27272727;
+    line-height: 1.25;
   }
   h2 em,
   .h2 em,
@@ -1517,6 +2232,12 @@ h2 b,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
   }
   .lt-ie9 h2 em,
   .lt-ie9 .h2 em,
@@ -1538,15 +2259,348 @@ h2 b,
   .lt-ie9 .h2 b {
     font-weight: normal !important;
   }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
 }
 h3,
 .h3 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
-  margin-bottom: 0.95454545em;
+  margin-bottom: 0.68181818em;
   font-size: 1.375em;
-  line-height: 1.27272727;
+  line-height: 1.25;
 }
 h3 em,
 .h3 em,
@@ -1555,6 +2609,12 @@ h3 i,
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
 }
 .lt-ie9 h3 em,
 .lt-ie9 .h3 em,
@@ -1576,15 +2636,218 @@ h3 b,
 .lt-ie9 .h3 b {
   font-weight: normal !important;
 }
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+p + h3,
+p + .h3,
+ul + h3,
+ul + .h3,
+ol + h3,
+ol + .h3,
+dl + h3,
+dl + .h3,
+figure + h3,
+figure + .h3,
+img + h3,
+img + .h3,
+table + h3,
+table + .h3,
+blockquote + h3,
+blockquote + .h3,
+h1 + h3,
+h1 + .h3,
+.h1 + h3,
+.h1 + .h3,
+h2 + h3,
+h2 + .h3,
+.h2 + h3,
+.h2 + .h3,
+h4 + h3,
+h4 + .h3,
+.h4 + h3,
+.h4 + .h3,
+h5 + h3,
+h5 + .h3,
+.h5 + h3,
+.h5 + .h3,
+h6 + h3,
+h6 + .h3,
+.h6 + h3,
+.h6 + .h3 {
+  margin-top: 1.36363636em;
+}
 @media only all and (max-width: 37.5em) {
   h3,
   .h3 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: 500;
-    margin-bottom: 1.16666667em;
+    margin-bottom: 0.83333333em;
     font-size: 1.125em;
-    line-height: 1.22222222;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
   }
   .lt-ie9 h3,
   .lt-ie9 .h3 {
@@ -1596,96 +2859,418 @@ h4,
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: 500;
-  margin-bottom: 1.16666667em;
+  margin-bottom: 0.83333333em;
   font-size: 1.125em;
-  line-height: 1.22222222;
+  line-height: 1.25;
 }
 .lt-ie9 h4,
 .lt-ie9 .h4 {
   font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+p + h4,
+p + .h4,
+ul + h4,
+ul + .h4,
+ol + h4,
+ol + .h4,
+dl + h4,
+dl + .h4,
+figure + h4,
+figure + .h4,
+img + h4,
+img + .h4,
+table + h4,
+table + .h4,
+blockquote + h4,
+blockquote + .h4,
+h1 + h4,
+h1 + .h4,
+.h1 + h4,
+.h1 + .h4,
+h2 + h4,
+h2 + .h4,
+.h2 + h4,
+.h2 + .h4,
+h3 + h4,
+h3 + .h4,
+.h3 + h4,
+.h3 + .h4,
+h5 + h4,
+h5 + .h4,
+.h5 + h4,
+.h5 + .h4,
+h6 + h4,
+h6 + .h4,
+.h6 + h4,
+.h6 + .h4 {
+  margin-top: 1.66666667em;
 }
 h5,
 .h5 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-bottom: 0.35714286em;
+  margin-bottom: 1.07142857em;
   font-size: 0.875em;
-  line-height: 1.57142857;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 .lt-ie9 h5,
 .lt-ie9 .h5 {
   font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+p + h5,
+p + .h5,
+ul + h5,
+ul + .h5,
+ol + h5,
+ol + .h5,
+dl + h5,
+dl + .h5,
+figure + h5,
+figure + .h5,
+img + h5,
+img + .h5,
+table + h5,
+table + .h5,
+blockquote + h5,
+blockquote + .h5,
+h1 + h5,
+h1 + .h5,
+.h1 + h5,
+.h1 + .h5,
+h2 + h5,
+h2 + .h5,
+.h2 + h5,
+.h2 + .h5,
+h3 + h5,
+h3 + .h5,
+.h3 + h5,
+.h3 + .h5,
+h4 + h5,
+h4 + .h5,
+.h4 + h5,
+.h4 + .h5,
+h6 + h5,
+h6 + .h5,
+.h6 + h5,
+.h6 + .h5 {
+  margin-top: 2.14285714em;
 }
 h6,
 .h6 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-bottom: 0.41666667em;
+  margin-bottom: 1.25em;
   font-size: 0.75em;
-  line-height: 1.83333333;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 .lt-ie9 h6,
 .lt-ie9 .h6 {
   font-weight: normal !important;
 }
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+p + h6,
+p + .h6,
+ul + h6,
+ul + .h6,
+ol + h6,
+ol + .h6,
+dl + h6,
+dl + .h6,
+figure + h6,
+figure + .h6,
+img + h6,
+img + .h6,
+table + h6,
+table + .h6,
+blockquote + h6,
+blockquote + .h6,
+h1 + h6,
+h1 + .h6,
+.h1 + h6,
+.h1 + .h6,
+h2 + h6,
+h2 + .h6,
+.h2 + h6,
+.h2 + .h6,
+h3 + h6,
+h3 + .h6,
+.h3 + h6,
+.h3 + .h6,
+h4 + h6,
+h4 + .h6,
+.h4 + h6,
+.h4 + .h6,
+h5 + h6,
+h5 + .h6,
+.h5 + h6,
+.h5 + .h6 {
+  margin-top: 2.5em;
+}
+.lead-paragraph,
+.subheader,
 .subheader {
-  font-weight: 500;
-  margin-bottom: 1.16666667em;
-  font-size: 1.125em;
-  line-height: 1.22222222;
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+  margin-top: 1.36363636em;
+  margin-bottom: 0.83333333em;
 }
-.lt-ie9 .subheader {
-  font-weight: normal !important;
-}
-.subheader em,
-.subheader i {
+.lead-paragraph em,
+.lead-paragraph i {
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
 }
-.lt-ie9 .subheader em,
-.lt-ie9 .subheader i {
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
   font-style: normal !important;
 }
-.subheader strong,
-.subheader b {
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
 }
-.lt-ie9 .subheader strong,
-.lt-ie9 .subheader b {
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
   font-weight: normal !important;
 }
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+.superheading,
+.superheader,
 .superheader {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
-  font-weight: bold;
-  margin-bottom: 0.1875em;
+  font-weight: normal;
+  margin-bottom: 0.41666667em;
   font-size: 3em;
   line-height: 1.25;
 }
-.lt-ie9 .superheader {
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
   font-weight: normal !important;
 }
 /* topdoc
-  name: Margins
+  name: Body copy element vertical margins
   family: cf-core
   patterns:
     - name: Consistent vertical margins
       notes:
-        - "Assumes that the font size of each of these items remains the default."
+        - Applies 15px bottom margin to all p, ul, ol, dl, figure, table, and blockquote elements.
+        - Applies -5px top margin to lists following paragraphs to reduce margin between them to 10px.
+        - Applies 8px bottom margin to list items that are not within a nav element.
+        - Assumes that the font size of each of these items remains the default.
       markup: |
         <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
         <p>Paragraph margin example</p>
   tags:
     - cf-core
@@ -1694,10 +3279,21 @@ p,
 ul,
 ol,
 dl,
+figure,
 table,
-figure {
+blockquote {
   margin-top: 0;
-  margin-bottom: 1.25em;
+  margin-bottom: 0.9375em;
+}
+p + ul,
+p + ol {
+  margin-top: -0.3125em;
+}
+:not(nav) li {
+  margin-bottom: 0.5em;
+}
+.lt-ie9 nav li {
+  margin-bottom: 0;
 }
 /* topdoc
   name: Default link
@@ -1831,16 +3427,32 @@ nav a {
   patterns:
     - name: Unordered list
       markup: |
+        <p>Paragraph example for visual reference</p>
         <ul>
-            <li>List item</li>
-            <li>List item</li>
-            <li>List item</li>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
         </ul>
+    - name: Ordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ol>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ol>
   tags:
     - cf-core
 */
 ul {
+  padding-left: 2em;
   list-style: square;
+}
+ol {
+  padding-left: 1.9375em;
+}
+ol > li {
+  padding-left: 0.0625em;
 }
 /* topdoc
   name: Tables
@@ -1892,11 +3504,47 @@ table i {
 .lt-ie9 table i {
   font-style: normal !important;
 }
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
 table strong,
 table b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
 }
 .lt-ie9 table strong,
 .lt-ie9 table b {
@@ -1913,15 +3561,119 @@ thead td {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-bottom: 0.35714286em;
+  margin-bottom: 1.07142857em;
   font-size: 0.875em;
-  line-height: 1.57142857;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 .lt-ie9 thead th,
 .lt-ie9 thead td {
   font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
 }
 thead,
 tbody tr {
@@ -1932,6 +3684,9 @@ th {
   font-style: normal;
   font-weight: bold;
   text-align: left;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
 }
 .lt-ie9 th {
   font-weight: normal !important;
@@ -1951,11 +3706,47 @@ tbody th i {
 .lt-ie9 tbody th i {
   font-style: normal !important;
 }
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
 tbody th strong,
 tbody th b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
 }
 .lt-ie9 tbody th strong,
 .lt-ie9 tbody th b {
@@ -1987,11 +3778,19 @@ tbody th b {
     - cf-core
 */
 blockquote {
-  margin: 1.25em;
+  margin-right: 0.9375em;
+  margin-left: 0.9375em;
 }
 @media only all and (min-width: 37.5625em) {
   blockquote {
-    margin: 1.75em 2.5em;
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
   }
 }
 /* topdoc
@@ -2033,11 +3832,3537 @@ label i {
 .lt-ie9 label i {
   font-style: normal !important;
 }
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
 label strong,
 label b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label input[type="radio"],
+label input[type="checkbox"] {
+  margin-right: 0.375em;
+}
+/* topdoc
+    name: Form elements
+    family: cf-core
+    notes:
+      - "The .focus class is only included for documentation demos and should
+         not be used in production."
+      - "Visit https://github.com/cfpb/cf-forms for advanced form field patterns."
+    patterns:
+    - name: type="text"
+      markup: |
+        <input type="text" value="Lorem ipsum">
+        <input class="focus" type="text" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="text" value="">
+    - name: type="search"
+      markup: |
+        <input type="search" value="Lorem ipsum">
+        <input class="focus" type="search" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="search" value="">
+    - name: type="email"
+      markup: |
+        <input type="email" value="Lorem ipsum">
+        <input class="focus" type="email" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="email" value="">
+    - name: type="url"
+      markup: |
+        <input type="url" value="Lorem ipsum">
+        <input class="focus" type="url" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="url" value="">
+    - name: type="tel"
+      markup: |
+        <input type="tel" value="Lorem ipsum">
+        <input class="focus" type="tel" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="tel" value="">
+    - name: type="number"
+      markup: |
+        <input type="number" value="1000">
+        <input class="focus" type="number" value="1000">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="number" value="">
+    - name: textarea
+      markup: |
+        <textarea>Lorem ipsum</textarea>
+        <textarea class="focus">Lorem ipsum</textarea>
+    - name: multi-select
+      markup: |
+        <select multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+        <select class="focus" multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+    tags:
+    - cf-core
+*/
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="number"],
+textarea,
+select[multiple] {
+  display: inline-block;
+  margin: 0;
+  padding: 0.375em;
+  font-family: Arial, sans-serif;
+  font-size: 1em;
+  background: #ffffff;
+  border: 1px solid #5b616b;
+  border-radius: 0;
+  vertical-align: top;
+  -webkit-appearance: none;
+  -webkit-user-modify: read-write-plaintext-only;
+}
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+input[type="text"]:focus,
+input[type="text"].focus,
+input[type="search"]:focus,
+input[type="search"].focus,
+input[type="email"]:focus,
+input[type="email"].focus,
+input[type="url"]:focus,
+input[type="url"].focus,
+input[type="tel"]:focus,
+input[type="tel"].focus,
+input[type="number"]:focus,
+input[type="number"].focus,
+textarea:focus,
+textarea.focus,
+select[multiple]:focus,
+select[multiple].focus {
+  border: 1px solid #3e94cf;
+  outline: 1px solid #3e94cf;
+  outline-offset: 0;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+::-webkit-input-placeholder {
+  color: grayscale(#c7336e);
+}
+::-moz-placeholder {
+  color: grayscale(#c7336e);
+}
+:-ms-input-placeholder {
+  color: grayscale(#c7336e);
+}
+/* topdoc
+  name: Images
+  family: cf-core
+  patterns:
+    - name: max-width
+      markup: |
+            <img src="http://placekitten.com/800/40" alt="">
+      notes:
+        - "Gives all images a default max-width of 100% of their container."
+  tags:
+    - cf-core
+*/
+img {
+  max-width: 100%;
+}
+/* topdoc
+  name: Figure
+  family: cf-core
+  patterns:
+    - name: figure
+      markup: |
+        <figure>
+            <img src="http://placekitten.com/340/320">
+        </figure>
+    - name: figure.figure__bordered
+      markup: |
+        <figure class="figure__bordered">
+            <img src="http://placekitten.com/340/320">
+        </figure>
+  tags:
+    - cf-core
+*/
+figure {
+  margin-left: 0;
+  margin-right: 0;
+}
+figure img {
+  vertical-align: middle;
+}
+.figure__bordered img {
+  border: 1px solid #d6d7d9;
+}
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Core Less file
+   ========================================================================== */
+/* ==========================================================================
+   Capital Framework
+   Less variables
+   ========================================================================== */
+/* topdoc
+  name: Theme variables
+  family: cf-core
+  notes:
+    - "The following color and sizing variables are exposed, allowing you to
+       easily override them before compiling."
+  patterns:
+    - name: Sizing
+      codenotes:
+        - |
+          @base-font-size-px
+          @base-line-height-px
+          @base-line-height
+          @bp-xs-max
+          @bp-sm-min
+          @bp-sm-max
+          @bp-med-min
+          @bp-med-max
+          @bp-lg-min
+          @bp-lg-max
+          @bp-xl-min
+    - name: Colors
+      codenotes:
+        - |
+          @text
+          @link-text
+          @link-underline
+          @link-text-visited
+          @link-underline-visited
+          @link-text-hover
+          @link-underline-hover
+          @link-text-active
+          @link-underline-active
+          @table-border
+          @thead-text
+          @thead-bg
+          @td-bg
+          @td-bg-alt
+          @input-bg
+          @input-border
+          @input-border-focus
+          @input-placeholder
+          @figure__bordered
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Media queries
+   ========================================================================== */
+/* topdoc
+  name: Media query mixins
+  family: cf-core
+  notes:
+    - "These mixins allow us to write consistent media queries using pixel
+      values, which are easier to remember. The mixins handle converting the
+      pixels into em's."
+  patterns:
+    - name: "min-width/max-width media queries"
+      codenotes:
+        - ".respond-to-min(@bp, @rules)"
+        - ".respond-to-max(@bp, @rules)"
+      notes:
+        - "@bp: the breakpoint size in pixels. It will get converted into em's."
+        - "@rules: a CSS or Less ruleset. Note that it can contain the full set
+          of Less features."
+    - name: "min-width/max-width media query usage"
+      codenotes:
+        - |
+            .respond-to-min(768px, {
+                .title {
+                    font-size: 2em;
+                }
+            });
+
+            Compiles to:
+
+            @media only all and (min-width: 48em) {
+                .title {
+                    font-size: 2em;
+                }
+            }
+    - name: "min-width/max-width media query range"
+      codenotes:
+        - ".respond-to-range(@bp1, @bp2, @rules)"
+      notes:
+        - "@bp1: the min-width breakpoint size in pixels.
+          It will get converted into em's."
+        - "@bp2: the max-width breakpoint size in pixels.
+          It will get converted into em's."
+        - "@rules: a CSS or Less ruleset. Note that it can contain the full set
+          of Less features."
+    - name: "min-width/max-width media query range usage"
+      codenotes:
+        - |
+            .respond-to-range(320px, 768px, {
+                .title {
+                    font-size: 2em;
+                }
+            });
+
+            Compiles to:
+
+            @media only all and (min-width: 20em) and (max-width: 48em) {
+                .title {
+                    font-size: 2em;
+                }
+            }
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Utilities
+   ========================================================================== */
+/* topdoc
+  name: JS-only
+  family: cf-core
+  patterns:
+    - name: Setup
+      codenotes:
+        - <html class="no-js">
+        - |
+            <script>
+                // Confirm availability of JS and remove no-js class from html
+                var docElement = document.documentElement;
+                docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
+            </script>
+      notes:
+        - "First add the .no-js class to the HTML element."
+        - "Then add the script to your HEAD which removes the .no-js class when
+           JS is available."
+    - name: Utility class
+      codenotes:
+        - .u-js-only;
+      notes:
+        - "Hide stuff when JavaScript isn't available. Depends on having a small
+           script in the HEAD of your HTML document that removes a .no-js class."
+  tags:
+    - cf-core
+*/
+.no-js .u-js-only {
+  display: none !important;
+}
+/* topdoc
+  name: Clearfix
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <div class="u-clearfix">
+            <div style="float:left; width:100%; height:60px; background:black;"></div>
+        </div>
+      codenotes:
+        - .u-clearfix;
+      notes:
+        - "Use this class to clear floats. For example, without .u-clearfix the
+           black box would spill into the markup section."
+        - "More information: http://css-tricks.com/snippets/css/clear-fix/"
+  tags:
+    - cf-core
+*/
+.u-clearfix:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.lt-ie8 .u-clearfix {
+  zoom: 1;
+}
+/* topdoc
+  name: Visually hidden
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <h1>
+            <a href="#">
+                <span class="cf-icon cf-icon-twitter-square"></span>
+                <span class="u-visually-hidden">Share on Twitter</span>
+            </a>
+        </h1>
+      codenotes:
+        - .u-visually-hidden;
+      notes:
+        - "Use this class to hide something from view while keeping it
+          accessible to screen readers."
+  tags:
+    - cf-core
+*/
+.u-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+/* topdoc
+  name: Inline block
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - .u-inline-block;
+      notes:
+        - "Also adds a .lt-ie8 class to hack inline-block for IE 7 and below."
+  tags:
+    - cf-core
+*/
+.u-inline-block {
+  display: inline-block;
+}
+.lt-ie8 .u-inline-block {
+  display: inline;
+}
+/* topdoc
+  name: Floating right
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - .u-right;
+      notes:
+        - "IE7 float: right drop bug fixes:"
+        - "1. If the float: right follows an element in the html structure that
+          should be to its left (and not above it), then that preceding
+          element(s) must be float: left.
+          http://stackoverflow.com/questions/10981767/clean-css-fix-of-ie7s-float-right-drop-bug#answer-11437688"
+        - "2. Simply change the markup order so that the element floating right
+          comes before the element to its left."
+  tags:
+    - cf-core
+*/
+.u-right {
+  float: right;
+}
+/* topdoc
+  name: Break word
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <div style="width: 100px;">
+            This link should break:
+            <br>
+            <a class="u-break-word" href="#">
+                something@something.com
+            </a>
+            <br>
+            <br>
+            This link should not:
+            <br>
+            <a href="#">
+                something@something.com
+            </a>
+        </div>
+      codenotes:
+        - .u-break-word
+      notes:
+        - "Use this on elements where you need the words to break when confined
+           to small containers."
+        - "This only works in IE8 when the element with the .u-break-word class
+           has layout. See <http://stackoverflow.com/questions/3997223/word-wrapbreak-word-not-working-in-ie8>
+           for more information."
+  tags:
+    - cf-core
+*/
+.u-break-word {
+  word-break: break-all;
+}
+/* topdoc
+  name: Align with button
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - ".u-align-with-btn(@font-size: @base-font-size-px);"
+      notes:
+        - "Adds top padding (among other things) to help alignment with buttons."
+        - "If you pass no arguments then the padding will be calculated using
+          @base-font-size-px."
+        - "Pass one argument to use a custom font size to calculate the top
+          padding."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Flexible proportional containers
+  family: cf-core
+  notes:
+    - "Utilizes intrinsic ratios to create a flexible container that retains its
+      aspect ratio. When image tags scale they retain their aspect ratio, but if
+      you need a flexible video you will need to use this mixin."
+    - "You can read more about intrinsic rations here:
+      http://alistapart.com/article/creating-intrinsic-ratios-for-video"
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="u-flexible-container">
+            <video
+              class="u-flexible-container_inner"
+              style="background:#75787B;"
+              controls>
+            </video>
+        </div>
+      notes:
+        - "Defaults to a 16:19 ratio."
+        - "Original mixin credit: https://gist.github.com/craigmdennis/6655047"
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container
+            .u-flexible-container_inner
+    - name: Background image examples
+      markup: |
+        <div class="u-flexible-container"
+             style="
+               background-image:url(http://placekitten.com/700/394);
+               background-position: center center;
+             ">
+        </div>
+        <div class="u-flexible-container"
+             style="
+               background-image:url(http://placekitten.com/700/394);
+               background-position: center center;
+               background-size: cover;
+             ">
+        </div>
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container
+      notes:
+        - "If you're not using the video or object elements and all you need is
+          a proportionally cropped or scaling background image with a fluid
+          container then you can leave out u-flexible-container_inner."
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+    - name: 4-3 modifier
+      markup: |
+        <div class="u-flexible-container u-flexible-container__4-3">
+            <video
+              class="u-flexible-container_inner"
+              style="background:#75787B;"
+              controls>
+            </video>
+        </div>
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container.u-flexible-container__4-3
+            .u-flexible-container_inner
+      notes:
+        - "Create your own aspect ratios by using this modifier as an example."
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+  tags:
+    - cf-core
+*/
+.u-flexible-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+}
+.u-flexible-container_inner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.u-flexible-container__4-3 {
+  position: relative;
+  padding-bottom: 75%;
+  height: 0;
+}
+/* topdoc
+  name: Link mixins
+  family: cf-core
+  patterns:
+    - codenotes:
+        - .u-link__colors();
+      notes:
+        - "Pass this mixin no arguments to color your link states with the
+          following defaults: :link (default state) pacific, :hover pacific-50,
+          :focus: pacific, :visited teal, :active navy."
+    - codenotes:
+        - .u-link__colors(@c);
+      notes:
+        - "Pass this mixin one color to be used on all of the following
+          states of your link; :link (default state), :visited, :hover, :focus,
+          :active."
+    - codenotes:
+        - .u-link__colors(@c, @h);
+      notes:
+        - "Pass this mixin two colors to use the first color for the :link,
+          :visited, and :active states, and the second color for the :hover and
+          :focus states."
+    - codenotes:
+        - .u-link__colors(@c, @v, @h, @f, @a);
+      notes:
+        - "Pass this mixin five colors in 'love/hate' mnemonic order to color
+          :link, :visited, :hover, :focus, and :active states respectively."
+        - "Even though this mixin is basically the same as
+          .u-link__colors-base(@c, @v, @h, @f, @a); we encourage you to use
+          .u-link__colors(@c, @v, @h, @f, @a) to promote consistency."
+    - codenotes:
+        - .u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba);
+      notes:
+        - "Allows you to color text and the borders separately."
+        - "The first five colors in 'love/hate' mnemonic order will color text
+          for the :link, :visited, :hover, :focus, and :active states
+          respectively. The last five colors in 'love/hate' mnemonic order will
+          color the borders for the :link, :visited, :hover, :focus, and :active
+          states respectively."
+        - "Even though this mixin is basically the same as
+          .u-link__colors-base(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba); we
+          encourage you to use .u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba)
+          to promote consistency."
+    - codenotes:
+        - .u-link__colors-base(@c, @v, @h, @f, @a);
+      notes:
+        - "This is the base mixin that all .u-link__colors() mixins use. Please
+          refrain from using this mixin directly in order to promote a
+          consistent use of mixin names for coloring links throughout this
+          project. Remember that if you need to set colors for all states of a
+          link you should use .u-link__colors(@c, @v, @h, @f, @a)."
+    - codenotes:
+        - .u-link__border();
+      notes:
+        - "Forces the default bottom border on the :link and :hover states."
+    - codenotes:
+        - .u-link__no-border();
+      notes:
+        - "Turn off the default bottom border on the :link and :hover states."
+    - codenotes:
+        - .u-link__hover-border();
+      notes:
+        - "Turn off the default bottom border on the :link state and force a
+          bottom border on the :hover state."
+    - codenotes:
+        - .u-link-child__hover();
+      notes:
+        - "When a link has child elements you may want only certain children to
+          change color when the parent link is hovered.
+          Pass no arguments to this mixin to color the child element pacific
+          when the parent link is hovered."
+    - codenotes:
+        - .u-link-child__hover(@c);
+      notes:
+        - "Pass this mixin one color to color the child element when the parent
+          link is hovered."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Margin utilities
+  family: cf-core
+  patterns:
+    - name: Utility classes
+      codenotes:
+        - .u-m<p><#>;
+      notes:
+        - "Replace <p> with the first letter of the position ('t' for top or 'b'
+           for bottom) and <#> with the pixel value of the margin you want."
+        - "Available values: 0, 5, 10, 15, 20, 30, 45, 60."
+  tags:
+    - cf-core
+*/
+.u-mt0 {
+  margin-top: 0 !important;
+}
+.u-mb0 {
+  margin-bottom: 0 !important;
+}
+.u-mt5 {
+  margin-top: 5px !important;
+}
+.u-mb5 {
+  margin-bottom: 5px !important;
+}
+.u-mt10 {
+  margin-top: 10px !important;
+}
+.u-mb10 {
+  margin-bottom: 10px !important;
+}
+.u-mt15 {
+  margin-top: 15px !important;
+}
+.u-mb15 {
+  margin-bottom: 15px !important;
+}
+.u-mt20 {
+  margin-top: 20px !important;
+}
+.u-mb20 {
+  margin-bottom: 20px !important;
+}
+.u-mt30 {
+  margin-top: 30px !important;
+}
+.u-mb30 {
+  margin-bottom: 30px !important;
+}
+.u-mt45 {
+  margin-top: 45px !important;
+}
+.u-mb45 {
+  margin-bottom: 45px !important;
+}
+.u-mt60 {
+  margin-top: 60px !important;
+}
+.u-mb60 {
+  margin-bottom: 60px !important;
+}
+/* topdoc
+  name: Width utilities
+  family: cf-core
+  patterns:
+    - name: Percent-based
+      markup: |
+        <div class="u-w100pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w100pct</code>
+        </div>
+        <div class="u-w90pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w90pct</code>
+        </div>
+        <div class="u-w80pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w80pct</code>
+        </div>
+        <div class="u-w70pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w70pct</code>
+        </div>
+        <div class="u-w60pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w60pct</code>
+        </div>
+        <div class="u-w50pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w50pct</code>
+        </div>
+        <div class="u-w40pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w40pct</code>
+        </div>
+        <div class="u-w30pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w30pct</code>
+        </div>
+        <div class="u-w20pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w20pct</code>
+        </div>
+        <div class="u-w10pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w10pct</code>
+        </div>
+        <div class="u-w75pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w75pct</code>
+        </div>
+        <div class="u-w25pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w25pct</code>
+        </div>
+        <div class="u-w66pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w66pct</code>
+        </div>
+        <div class="u-w33pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w33pct</code>
+        </div>
+      notes:
+        - "Inline styles are for demonstration purposes only, please don't use
+           them."
+  tags:
+    - cf-core
+*/
+.u-w100pct {
+  width: 100%;
+}
+.u-w90pct {
+  width: 90%;
+}
+.u-w80pct {
+  width: 80%;
+}
+.u-w70pct {
+  width: 70%;
+}
+.u-w60pct {
+  width: 60%;
+}
+.u-w50pct {
+  width: 50%;
+}
+.u-w40pct {
+  width: 40%;
+}
+.u-w30pct {
+  width: 30%;
+}
+.u-w20pct {
+  width: 20%;
+}
+.u-w10pct {
+  width: 10%;
+}
+.u-w75pct {
+  width: 75%;
+}
+.u-w25pct {
+  width: 25%;
+}
+.u-w66pct {
+  width: 66.66666667%;
+}
+.u-w33pct {
+  width: 33.33333333%;
+}
+/* topdoc
+  name: Width-specific display
+  family: cf-core
+  patterns:
+    - name: Show on mobile
+      markup: |
+        <section>
+            <p>The the text in the box below is visible only at widths less than 600px</p>
+            <div style="border: 1px solid black; height: 22px; padding: 5px;">
+                <p class="u-show-on-mobile">Visible on mobile</p>
+            </div>
+        </section>
+      codenotes:
+        - ".u-show-on-mobile"
+        - "Uses 'display:block' to toggle display. Would need to be extended
+          for inline use cases."
+      notes:
+        - "Displays an element only at mobile widths."
+    - name: Hide on mobile
+      markup: |
+        <section>
+            <p>The text in the box below is hidden at widths less than 600px</p>
+            <div style="border: 1px solid black; height: 22px; padding: 5px;">
+                <p class="u-hide-on-mobile">Hidden on mobile</p>
+            </div>
+        </section>
+      codenotes:
+        - ".u-hide-on-mobile"
+      notes:
+        - "Hides an element at mobile widths"
+  tags:
+    - cf-core
+*/
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+.u-show-on-mobile {
+  display: none;
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+/* topdoc
+  name: Small text utility
+  family: cf-core
+  patterns:
+    - name: .u-small-text (utility class)
+      markup: |
+        Lorem ipsum<br>
+        <span class="u-small-text">dolor sit amet</span>
+      codenotes:
+        - ".u-small-text"
+      notes:
+        - "14px text."
+        - "The utility class should only be used when the default text size is
+           16px. For example you wouldn't want to use the class inside of an
+           `h1` because the `font-size` in the `h1` will make `.u-small-text`
+           bigger than it should be. See the docs for the `.u-small-text()`
+           mixin."
+    - name: .u-small-text() (Less mixin)
+      codenotes:
+        - ".u-small-text(@context)"
+        - |
+          // Mixin usage:
+          .example {
+            font-size: unit(20px / @base-font-size-px, em);
+            small {
+              .u-small-text(20px);
+            }
+          }
+          // Compiles to:
+          .example {
+            font-size: 1.25em;
+          }
+          .example small {
+            font-size: 0.7em;
+          }
+      notes:
+        - "This mixin enables you to easily create consistent small text by
+           passing the context `font-size`."
+  tags:
+    - cf-core
+*/
+.u-small-text {
+  font-size: 0.875em;
+}
+small {
+  font-size: 0.875em;
+}
+/* topdoc
+    name: EOF
+    eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Base styles
+   ========================================================================== */
+/* topdoc
+  name: Webfonts
+  family: cf-core
+  patterns:
+    - name: Webfont mixins and variables
+      codenotes:
+        - ".webfont-regular()"
+        - ".webfont-italic()"
+        - ".webfont-medium()"
+        - ".webfont-demi()"
+      notes:
+        - "Use these mixins to easily add the your preferred font family to your
+          elements."
+        - "To use your own fonts in the webfont mixins, set your own font with the
+          @webfont-regular/italic/medium/demi variables."
+        - "To avoid faux bold and italics,
+          you must use the font family name for that particular style.
+          For example, when defining an italic in Helvetica
+          you need to use the Helvetica Italic font family.
+          Use the mixins when setting bold or italic text as they also
+          set the appropriate font-weight and font-style."
+        - "These mixins also add the appropriate .lt-ie9 overrides.
+          .lt-ie9 overrides are necessary to override font-style and font-weight
+          each time the webfont is used. These overrides are built into the webfont
+          mixins so you get them automatically. Note that this requires you to
+          use conditional classes on the <html> element:
+          https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md#conditional-html-classes."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Type hierarchy
+  family: cf-core
+  patterns:
+    - name: Default body type
+      markup: |
+        <p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    - name: Heading level 1
+      markup: |
+        <h1>Example heading element</h1>
+        <p class="h1">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h2.
+    - name: Heading level 2
+      markup: |
+        <h2>Example heading element</h2>
+        <p class="h2">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h3.
+    - name: Heading level 3
+      markup: |
+        <h3>Example heading element</h3>
+        <p class="h3">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h4.
+    - name: Heading level 4
+      markup: |
+        <h4>Example heading element</h4>
+        <p class="h4">A non-heading element</p>
+    - name: Heading level 5
+      markup: |
+        <h5>Example heading element</h5>
+        <p class="h5">A non-heading element</p>
+    - name: Heading level 6
+      markup: |
+        <h6>Example heading element</h6>
+        <p class="h6">A non-heading element</p>
+    - name: Lead paragraph
+      markup: |
+        <p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      notes:
+        - Responsive. Displays as an h3 on large screens; displays at h4 size (but still Regular weight) on small screens.
+    - name: Display heading (aka "superheading")
+      markup: |
+        <h1 class="superheading">Example display heading</h1>
+  tags:
+    - cf-core
+*/
+body {
+  color: #212121;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 100%;
+  line-height: 1.375;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+}
+h1,
+.h1 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.44117647em;
+  font-size: 2.125em;
+  line-height: 1.25;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+p + h1,
+p + .h1,
+ul + h1,
+ul + .h1,
+ol + h1,
+ol + .h1,
+dl + h1,
+dl + .h1,
+figure + h1,
+figure + .h1,
+img + h1,
+img + .h1,
+table + h1,
+table + .h1,
+blockquote + h1,
+blockquote + .h1 {
+  margin-top: 1.76470588em;
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+h2,
+.h2 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.57692308em;
+  font-size: 1.625em;
+  line-height: 1.25;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+p + h2,
+p + .h2,
+ul + h2,
+ul + .h2,
+ol + h2,
+ol + .h2,
+dl + h2,
+dl + .h2,
+figure + h2,
+figure + .h2,
+img + h2,
+img + .h2,
+table + h2,
+table + .h2,
+blockquote + h2,
+blockquote + .h2 {
+  margin-top: 1.73076923em;
+}
+h1 + h2,
+h1 + .h2,
+.h1 + h2,
+.h1 + .h2,
+h3 + h2,
+h3 + .h2,
+.h3 + h2,
+.h3 + .h2,
+h4 + h2,
+h4 + .h2,
+.h4 + h2,
+.h4 + .h2,
+h5 + h2,
+h5 + .h2,
+.h5 + h2,
+.h5 + .h2,
+h6 + h2,
+h6 + .h2,
+.h6 + h2,
+.h6 + .h2 {
+  margin-top: 1.15384615em;
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+h3,
+.h3 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+p + h3,
+p + .h3,
+ul + h3,
+ul + .h3,
+ol + h3,
+ol + .h3,
+dl + h3,
+dl + .h3,
+figure + h3,
+figure + .h3,
+img + h3,
+img + .h3,
+table + h3,
+table + .h3,
+blockquote + h3,
+blockquote + .h3,
+h1 + h3,
+h1 + .h3,
+.h1 + h3,
+.h1 + .h3,
+h2 + h3,
+h2 + .h3,
+.h2 + h3,
+.h2 + .h3,
+h4 + h3,
+h4 + .h3,
+.h4 + h3,
+.h4 + .h3,
+h5 + h3,
+h5 + .h3,
+.h5 + h3,
+.h5 + .h3,
+h6 + h3,
+h6 + .h3,
+.h6 + h3,
+.h6 + .h3 {
+  margin-top: 1.36363636em;
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+h4,
+.h4 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  margin-bottom: 0.83333333em;
+  font-size: 1.125em;
+  line-height: 1.25;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+p + h4,
+p + .h4,
+ul + h4,
+ul + .h4,
+ol + h4,
+ol + .h4,
+dl + h4,
+dl + .h4,
+figure + h4,
+figure + .h4,
+img + h4,
+img + .h4,
+table + h4,
+table + .h4,
+blockquote + h4,
+blockquote + .h4,
+h1 + h4,
+h1 + .h4,
+.h1 + h4,
+.h1 + .h4,
+h2 + h4,
+h2 + .h4,
+.h2 + h4,
+.h2 + .h4,
+h3 + h4,
+h3 + .h4,
+.h3 + h4,
+.h3 + .h4,
+h5 + h4,
+h5 + .h4,
+.h5 + h4,
+.h5 + .h4,
+h6 + h4,
+h6 + .h4,
+.h6 + h4,
+.h6 + .h4 {
+  margin-top: 1.66666667em;
+}
+h5,
+.h5 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+p + h5,
+p + .h5,
+ul + h5,
+ul + .h5,
+ol + h5,
+ol + .h5,
+dl + h5,
+dl + .h5,
+figure + h5,
+figure + .h5,
+img + h5,
+img + .h5,
+table + h5,
+table + .h5,
+blockquote + h5,
+blockquote + .h5,
+h1 + h5,
+h1 + .h5,
+.h1 + h5,
+.h1 + .h5,
+h2 + h5,
+h2 + .h5,
+.h2 + h5,
+.h2 + .h5,
+h3 + h5,
+h3 + .h5,
+.h3 + h5,
+.h3 + .h5,
+h4 + h5,
+h4 + .h5,
+.h4 + h5,
+.h4 + .h5,
+h6 + h5,
+h6 + .h5,
+.h6 + h5,
+.h6 + .h5 {
+  margin-top: 2.14285714em;
+}
+h6,
+.h6 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.25em;
+  font-size: 0.75em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+p + h6,
+p + .h6,
+ul + h6,
+ul + .h6,
+ol + h6,
+ol + .h6,
+dl + h6,
+dl + .h6,
+figure + h6,
+figure + .h6,
+img + h6,
+img + .h6,
+table + h6,
+table + .h6,
+blockquote + h6,
+blockquote + .h6,
+h1 + h6,
+h1 + .h6,
+.h1 + h6,
+.h1 + .h6,
+h2 + h6,
+h2 + .h6,
+.h2 + h6,
+.h2 + .h6,
+h3 + h6,
+h3 + .h6,
+.h3 + h6,
+.h3 + .h6,
+h4 + h6,
+h4 + .h6,
+.h4 + h6,
+.h4 + .h6,
+h5 + h6,
+h5 + .h6,
+.h5 + h6,
+.h5 + .h6 {
+  margin-top: 2.5em;
+}
+.lead-paragraph,
+.subheader,
+.subheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+  margin-top: 1.36363636em;
+  margin-bottom: 0.83333333em;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+.superheading,
+.superheader,
+.superheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.41666667em;
+  font-size: 3em;
+  line-height: 1.25;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+/* topdoc
+  name: Body copy element vertical margins
+  family: cf-core
+  patterns:
+    - name: Consistent vertical margins
+      notes:
+        - Applies 15px bottom margin to all p, ul, ol, dl, figure, table, and blockquote elements.
+        - Applies -5px top margin to lists following paragraphs to reduce margin between them to 10px.
+        - Applies 8px bottom margin to list items that are not within a nav element.
+        - Assumes that the font size of each of these items remains the default.
+      markup: |
+        <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
+        <p>Paragraph margin example</p>
+  tags:
+    - cf-core
+*/
+p,
+ul,
+ol,
+dl,
+figure,
+table,
+blockquote {
+  margin-top: 0;
+  margin-bottom: 0.9375em;
+}
+p + ul,
+p + ol {
+  margin-top: -0.3125em;
+}
+:not(nav) li {
+  margin-bottom: 0.5em;
+}
+.lt-ie9 nav li {
+  margin-bottom: 0;
+}
+/* topdoc
+  name: Default link
+  notes:
+    - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+      be used in production."
+  family: cf-core
+  patterns:
+    - name: Default state
+      markup: |
+        <a href="#">Default link style</a>
+    - name: Visited state
+      markup: |
+        <a href="#" class="visited">Visited link style</a>
+    - name: Hovered state
+      markup: |
+        <a href="#" class="hover">Hovered link style</a>
+    - name: Focused state
+      markup: |
+        <a href="#" class="focus">Focused link style</a>
+    - name: Active state
+      markup: |
+        <a href="#" class="active">Active link style</a>
+  tags:
+    - cf-core
+*/
+a {
+  border-width: 0;
+  border-style: dotted;
+  border-color: #0071bc;
+  color: #0071bc;
+  text-decoration: none;
+}
+a:visited,
+a.visited {
+  border-color: #4c2c92;
+  color: #4c2c92;
+}
+a:hover,
+a.hover {
+  border-style: solid;
+  border-color: #205493;
+  color: #205493;
+}
+a:focus,
+a.focus {
+  border-style: solid;
+  outline: thin dotted;
+}
+a:active,
+a.active {
+  border-style: solid;
+  border-color: #046b99;
+  color: #046b99;
+}
+/* topdoc
+  name: Underlined links
+  family: cf-core
+  patterns:
+    - name: States
+      notes:
+        - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+          be used in production."
+        - "The underline style properties are mostly set above in the a tag.
+          To enable the underline simply set a bottom-border-width as done here."
+      markup: |
+        <p>
+            <a href="#">Default</a>,
+            <a href="#" class="visited">Visited</a>,
+            <a href="#" class="hover">Hovered</a>,
+            <a href="#" class="focus">Focused</a>,
+            <a href="#" class="active">Active</a>
+        </p>
+    - name: Underline conditions
+      notes:
+        - "We're restricting link borders to links within p, li, and dd so that
+          we don't have to override them every time we want a plain link."
+      markup: |
+        <p>
+            <a href="#">A child of a paragraph</a>
+        </p>
+        <ul>
+            <li>
+                <a href="#">A child of a list item</a>
+            </li>
+        </ul>
+        <dl>
+            <dt>
+                Definition list term
+            </dt>
+            <dd>
+                <a href="#">A child of a definition list description</a>
+            </dd>
+        </dl>
+    - name: Exceptions for underlined links
+      notes:
+        - "Inline text links inside of a nav element are not underlined."
+      markup: |
+        <nav>
+            <p>
+                <a href="#">A child of a paragraph</a>
+            </p>
+            <ul>
+                <li>
+                    <a href="#">A child of a list item</a>
+                </li>
+            </ul>
+            <dl>
+                <dt>
+                    Definition list term
+                </dt>
+                <dd>
+                    <a href="#">A child of a definition list description</a>
+                </dd>
+            </dl>
+        </nav>
+  tags:
+    - cf-core
+*/
+p a,
+li a,
+dd a {
+  border-bottom-width: 1px;
+}
+nav a {
+  border-bottom-width: 0;
+}
+/* topdoc
+  name: Lists
+  family: cf-core
+  patterns:
+    - name: Unordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
+    - name: Ordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ol>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ol>
+  tags:
+    - cf-core
+*/
+ul {
+  padding-left: 2em;
+  list-style: square;
+}
+ol {
+  padding-left: 1.9375em;
+}
+ol > li {
+  padding-left: 0.0625em;
+}
+/* topdoc
+  name: Tables
+  family: cf-core
+  patterns:
+    - name: Standard table
+      markup: |
+        <table>
+            <thead>
+                <tr>
+                    <th>Column 1 header</th>
+                    <th>Column 2 header</th>
+                    <th>Column 3 header</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Row 1, column 1</td>
+                    <td>Row 1, column 2</td>
+                    <td>Row 1, column 3</td>
+                </tr>
+                <tr>
+                    <td>Row 2, column 1</td>
+                    <td>Row 2, column 2</td>
+                    <td>Row 2, column 3</td>
+                </tr>
+                <tr>
+                    <td>Row 3, column 1</td>
+                    <td>Row 3, column 2</td>
+                    <td>Row 3, column 3</td>
+                </tr>
+            </tbody>
+        </table>
+  tags:
+    - cf-core
+*/
+table {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+th,
+td {
+  padding: 0.625em;
+}
+thead th,
+thead td {
+  color: #212121;
+  background: #f1f1f1;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+thead,
+tbody tr {
+  border-bottom: 1px solid #5b616b;
+}
+th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  text-align: left;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+tbody th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+/* topdoc
+  name: Block quote
+  family: cf-core
+  patterns:
+    - name: Default block quote
+      markup: |
+        <blockquote cite="link-to-source">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Culpa
+            similique fugit hic eligendi praesentium officiis illum optio iusto
+            commodi eum tempore nisi ad in perferendis enim quo dolores.
+            Reprehenderit similique earum quibusdam possimus vitae esse
+            nesciunt mollitia sed beatae aliquid dolores iure a impedit quam
+            minus eum modi illum ducimus eligendi eveniet labore non sequi
+            voluptate et totam praesentium animi itaque asperiores dolorum
+            sunt laudantium repellat nam commodi. Perspiciatis natus aliquam
+            veniam officiis ducimus voluptatum ut necessitatibus non!
+        </blockquote>
+      notes:
+        - "Use a block quote to quote from an external work. See .pull-quote if
+          you need to highlight an excerpt from the current work."
+        - "It is best practice to document the URL of a quoted work using the
+          cite attribute."
+  tags:
+    - cf-core
+*/
+blockquote {
+  margin-right: 0.9375em;
+  margin-left: 0.9375em;
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+/* topdoc
+    name: Form labels
+    family: cf-core
+    notes:
+      - "Visit https://github.com/cfpb/cf-forms for advanced form label patterns."
+    patterns:
+    - name: Default label
+      markup: |
+        <label>Form label</label>
+    - name: Label wrapping a radio or checkbox
+      markup: |
+        <label>
+            <input type="radio">
+            Radio label
+        </label>
+        <label>
+            <input type="checkbox">
+            Checkbox label
+        </label>
+    tags:
+    - cf-core
+*/
+label {
+  display: block;
+  margin-bottom: 0.3125em;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
 }
 .lt-ie9 label strong,
 .lt-ie9 label b {
@@ -4275,6 +9600,14 @@ figure img {
 .lt-ie8 .expandable_content {
   zoom: 1;
 }
+.expandable_content:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.lt-ie8 .expandable_content {
+  zoom: 1;
+}
 /* topdoc
   name: Expandable text elements
   family: cf-expandables
@@ -4311,6 +9644,9 @@ figure img {
 .lt-ie9 .expandable_label {
   font-weight: normal !important;
 }
+.lt-ie9 .expandable_label {
+  font-weight: normal !important;
+}
 .expandable_link {
   color: #046b99;
   font-family: Arial, Arial, sans-serif;
@@ -4329,11 +9665,47 @@ figure img {
 .lt-ie9 .expandable_link i {
   font-style: normal !important;
 }
+.lt-ie9 .expandable_link em,
+.lt-ie9 .expandable_link i {
+  font-style: normal !important;
+}
 .expandable_link strong,
 .expandable_link b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 .expandable_link strong,
+.lt-ie9 .expandable_link b {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable_link strong,
+.lt-ie9 .expandable_link b {
+  font-weight: normal !important;
+}
+.expandable_link em,
+.expandable_link i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .expandable_link em,
+.lt-ie9 .expandable_link i {
+  font-style: normal !important;
+}
+.lt-ie9 .expandable_link em,
+.lt-ie9 .expandable_link i {
+  font-style: normal !important;
+}
+.expandable_link strong,
+.expandable_link b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .expandable_link strong,
+.lt-ie9 .expandable_link b {
+  font-weight: normal !important;
 }
 .lt-ie9 .expandable_link strong,
 .lt-ie9 .expandable_link b {
@@ -4454,6 +9826,14 @@ figure img {
 */
 .expandable_header {
   display: block;
+}
+.expandable_header:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.lt-ie8 .expandable_header {
+  zoom: 1;
 }
 .expandable_header:after {
   content: "";
@@ -4716,12 +10096,21 @@ button.expandable_header {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-bottom: 0.35714286em;
+  margin-bottom: 1.07142857em;
   font-size: 0.875em;
-  line-height: 1.57142857;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
   margin-bottom: 0;
+}
+.lt-ie9 .expandable-group_header {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable-group_header {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable-group_header {
+  font-weight: normal !important;
 }
 .lt-ie9 .expandable-group_header {
   font-weight: normal !important;
@@ -4735,10 +10124,19 @@ button.expandable_header {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: 500;
-  margin-bottom: 1.16666667em;
+  margin-bottom: 0.83333333em;
   font-size: 1.125em;
-  line-height: 1.22222222;
+  line-height: 1.25;
   margin-bottom: 0;
+}
+.lt-ie9 .expandable-group .expandable_label {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable-group .expandable_label {
+  font-weight: normal !important;
+}
+.lt-ie9 .expandable-group .expandable_label {
+  font-weight: normal !important;
 }
 .lt-ie9 .expandable-group .expandable_label {
   font-weight: normal !important;
@@ -4750,4 +10148,4 @@ button.expandable_header {
   name: EOF
   eof: true
 */
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1jc3Mvbm9ybWFsaXplLmNzcyIsIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1sZWdhY3ktYWRkb24vbm9ybWFsaXplLWxlZ2FjeS1hZGRvbi5jc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtdXRpbGl0aWVzLmxlc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtbWVkaWEtcXVlcmllcy5sZXNzIiwiLy4uL2NmLWNvcmUvc3JjL2NmLWJhc2UubGVzcyIsIi8uLi9jZi1jb3JlL3NyYy9jZi12YXJzLmxlc3MiLCIvLi4vY2YtaWNvbnMvc3JjL2NmLWljb25zLmxlc3MiLCIvc3JjL2NmLWV4cGFuZGFibGVzLmxlc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7OztBQVFBO0VBQ0UsdUJBQUE7O0VBQ0EsMEJBQUE7O0VBQ0EsOEJBQUE7Ozs7OztBQU9GO0VBQ0UsU0FBQTs7Ozs7Ozs7OztBQWFGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7QUFDQTtBQUNBO0FBQ0E7RUFDRSxxQkFBQTs7RUFDQSx3QkFBQTs7Ozs7OztBQVFGLEtBQUssSUFBSTtFQUNQLGFBQUE7RUFDQSxTQUFBOzs7Ozs7QUFRRjtBQUNBO0VBQ0UsYUFBQTs7Ozs7OztBQVVGO0VBQ0UsNkJBQUE7Ozs7OztBQVFGLENBQUM7QUFDRCxDQUFDO0VBQ0MsVUFBQTs7Ozs7OztBQVVGLElBQUk7RUFDRix5QkFBQTs7Ozs7QUFPRjtBQUNBO0VBQ0UsaUJBQUE7Ozs7O0FBT0Y7RUFDRSxrQkFBQTs7Ozs7O0FBUUY7RUFDRSxjQUFBO0VBQ0EsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSxnQkFBQTtFQUNBLFdBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7RUFDRSxjQUFBO0VBQ0EsY0FBQTtFQUNBLGtCQUFBO0VBQ0Esd0JBQUE7O0FBR0Y7RUFDRSxXQUFBOztBQUdGO0VBQ0UsZUFBQTs7Ozs7OztBQVVGO0VBQ0UsU0FBQTs7Ozs7QUFPRixHQUFHLElBQUk7RUFDTCxnQkFBQTs7Ozs7OztBQVVGO0VBQ0UsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSx1QkFBQTtFQUNBLFNBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsaUNBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7OztBQWtCRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7RUFDQSxhQUFBOztFQUNBLFNBQUE7Ozs7OztBQU9GO0VBQ0UsaUJBQUE7Ozs7Ozs7O0FBVUY7QUFDQTtFQUNFLG9CQUFBOzs7Ozs7Ozs7QUFXRjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0gsMEJBQUE7O0VBQ0EsZUFBQTs7Ozs7O0FBT0YsTUFBTTtBQUNOLElBQUssTUFBSztFQUNSLGVBQUE7Ozs7O0FBT0YsTUFBTTtBQUNOLEtBQUs7RUFDSCxTQUFBO0VBQ0EsVUFBQTs7Ozs7O0FBUUY7RUFDRSxtQkFBQTs7Ozs7Ozs7O0FBV0YsS0FBSztBQUNMLEtBQUs7RUFDSCxzQkFBQTs7RUFDQSxVQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsWUFBQTs7Ozs7O0FBUUYsS0FBSztFQUNILDZCQUFBOztFQUNBLHVCQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsd0JBQUE7Ozs7O0FBT0Y7RUFDRSx5QkFBQTtFQUNBLGFBQUE7RUFDQSw4QkFBQTs7Ozs7O0FBUUY7RUFDRSxTQUFBOztFQUNBLFVBQUE7Ozs7OztBQU9GO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7RUFDRSxpQkFBQTs7Ozs7OztBQVVGO0VBQ0UseUJBQUE7RUFDQSxpQkFBQTs7QUFHRjtBQUNBO0VBQ0UsVUFBQTs7Ozs7Ozs7O0FDNVpGO0FBQ0E7QUFDQTtFQUNJLGdCQUFBO0VBQ0EsUUFBQTs7Ozs7Ozs7O0FBWUo7RUFDSSxlQUFBOzs7Ozs7QUFRSjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksdUJBQUE7Ozs7Ozs7Ozs7QUFhSjtFQUNJLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsYUFBQTs7QUFHSjtFQUNJLGNBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7Ozs7O0FBT0o7QUFDQTtFQUNJLGFBQUE7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSxjQUFjLHdCQUFkOzs7OztBQU9KO0VBQ0ksZ0JBQUE7RUFDQSxxQkFBQTs7Ozs7QUFPSjtFQUNJLFlBQUE7Ozs7O0FBT0osQ0FBQztBQUNELENBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxhQUFBOzs7Ozs7OztBQVdKO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtFQUNJLGtCQUFBOzs7OztBQU9KO0FBQ0E7QUFDQTtFQUNJLG1CQUFBOzs7OztBQU9KLEdBQUk7QUFDSixHQUFJO0VBQ0EsZ0JBQUE7RUFDQSxzQkFBQTs7Ozs7Ozs7QUFXSjtFQUNJLCtCQUFBOzs7Ozs7OztBQVdKO0VBQ0ksU0FBQTs7Ozs7OztBQVNKO0VBQ0ksU0FBQTs7RUFDQSxtQkFBQTs7RUFDQSxrQkFBQTs7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSx3QkFBQTtFQUNBLHVCQUFBOzs7Ozs7QUFRSjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0Qsa0JBQUE7Ozs7OztBQVFKLEtBQUs7QUFDTCxLQUFLO0VBQ0QsYUFBQTtFQUNBLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDOU1BLE1BQU87RUFDSCx3QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF5QkosV0FBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBOztBQUVKLE9BQVE7RUFDSixPQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMEJSO0VBQ0Usa0JBQUE7RUFDQSxnQkFBQTtFQUNBLE1BQU0sYUFBTjtFQUNBLFdBQUE7RUFBYSxVQUFBO0VBQ2IsWUFBQTtFQUFjLFVBQUE7RUFBWSxTQUFBOzs7Ozs7Ozs7Ozs7OztBQWlCNUI7RUFDSSxxQkFBQTs7QUFDQSxPQUFRO0VBRUosZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3QlI7RUFDSSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvQ0o7RUFDSSxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbUhKO0VBTEksa0JBQUE7RUFDQSxzQkFBQTtFQUNBLFNBQUE7O0FBT0o7RUFDSSxrQkFBQTtFQUNBLE1BQUE7RUFDQSxPQUFBO0VBQ0EsV0FBQTtFQUNBLFlBQUE7O0FBR0o7RUFqQkksa0JBQUE7RUFDQSxtQkFBQTtFQUNBLFNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb05KO0VBQVUsd0JBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDBCQUFBOztBQUNWO0VBQVUsNkJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMERWO0VBQWEsV0FBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsbUJBQUE7O0FBQ2I7RUFBYSxtQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUM5ZmIscUJBSDBDO0VBRzFDO0lEcWlCUSxhQUFBOzs7QUFJUjtFQUNJLGFBQUE7O0FDMWlCSixxQkFIMEM7RUFHMUM7SUQ0aUJRLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbURSO0VBSEUsa0JBQUE7O0FBT0Y7RUFQRSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRXJpQkY7RUFDSSxjQUFBO0VBQ0Esc0JBQXNCLHdCQUF0QjtFQUNBLGVBQUE7RUFDQSxrQkFBQTs7QUFxRUo7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtBQUNBO0VBL0tJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXNHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBdEdBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUREUixxQkFIMEM7RUFHMUM7RUFBQTtJQ3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUFnSEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLHVCQUFBOztFQWhIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFQUNBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFQUNBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7OztBQWlKUjtBQUNBO0VBeExJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQWdIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBaEhBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUREUixxQkFIMEM7RUFHMUM7RUFBQTtJQ3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUEwSEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLHVCQUFBOztFQTFIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFQUNBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFQUNBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7OztBQTBKUjtBQUNBO0VBak1JLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQTBIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBMUhBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUREUixxQkFIMEM7RUFHMUM7RUFBQTtJQ1pJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQTJHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsdUJBQUE7O0VBNUdBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBQTRLUjtBQUNBO0VBakxJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQTJHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBNUdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBaUxSO0FBQ0E7RUE3S0kscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBMkdBLG1CQUFBO0VBQ0EseUJBQUE7RUFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBaEhBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBNktSO0FBQ0E7RUFsTEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBd0hBLG1CQUFBO0VBQ0EseUJBQUE7RUFHQSwyQkFBQTtFQUNBLGlCQUFBO0VBQ0EsdUJBQUE7O0FBN0hBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBa0xSO0VBN0xJLGdCQUFBO0VBMkdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSx1QkFBQTtFQXhJQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBMEJBLE9BQVE7RUFDSiw4QkFBQTs7QUF6QkosVUFBRTtBQUNGLFVBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxXQWZOO0FBZUYsT0FBUSxXQWROO0VBZUUsNkJBQUE7O0FBWEosVUFBRTtBQUNGLFVBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBQUNBLE9BQVEsV0E1Qk47QUE0QkYsT0FBUSxXQTNCTjtFQTRCRSw4QkFBQTs7QUF1TFI7RUEzTEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBaU1BLHVCQUFBO0VBQ0EsY0FBQTtFQUNBLGlCQUFBOztBQWxNQSxPQUFRO0VBQ0osOEJBQUE7Ozs7Ozs7Ozs7Ozs7OztBQW1OUjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDSSxhQUFBO0VBRUEscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQThCSjtFQUNJLGVBQUE7RUFDQSxvQkFBQTtFQUNBLHFCQUFBO0VBQ0EsY0FBQTtFQUNBLHFCQUFBOztBQUVBLENBQUM7QUFDRCxDQUFDO0VBQ0cscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7O0FBR0osQ0FBQztBQUNELENBQUM7RUFDRyxtQkFBQTtFQUNBLG9CQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNFUixDQUtJO0FBSkosRUFJSTtBQUhKLEVBR0k7RUFDSSx3QkFBQTs7QUFJUixHQUFJO0VBRUEsc0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7QUFtQko7RUFDSSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXdDSjtFQTNjSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBRUEsS0FBRTtBQUNGLEtBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FBWEosS0FBRTtBQUNGLEtBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBQUNBLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUF5YVI7QUFDQTtFQUNJLGdCQUFBOztBQUVBLEtBQU07QUFBTixLQUFNO0VBQ0YsY0FBQTtFQUNBLG1CQUFBO0VBbmJKLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQTJHQSxtQkFBQTtFQUNBLHlCQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBOztBQWhIQSxPQUFRLE1BOGFGO0FBOWFOLE9BQVEsTUE4YUY7RUE3YUYsOEJBQUE7O0FBb2JSO0FBQ0EsS0FBTTtFQUNGLGdDQUFBOztBQUdKO0VBN2JJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQTZiQSxnQkFBQTs7QUE1YkEsT0FBUTtFQUNKLDhCQUFBOztBQThiUixLQUFNO0VBcGVGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFFQSxLQWdlRSxHQWhlQTtBQUNGLEtBK2RFLEdBL2RBO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUNBLE9BQVEsTUFpZE4sR0FoZUE7QUFlRixPQUFRLE1BaWROLEdBL2RBO0VBZUUsNkJBQUE7O0FBWEosS0EyZEUsR0EzZEE7QUFDRixLQTBkRSxHQTFkQTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxNQStiTixHQTNkQTtBQTRCRixPQUFRLE1BK2JOLEdBMWRBO0VBNEJFLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE0ZFI7RUFFSSxjQUFBOztBRHRlSixxQkFIMEM7RUFHMUM7SUN5ZVEsb0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE2QlI7RUFDSSxjQUFBO0VBRUEsdUJBQUE7RUF2aUJBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFFQSxLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFDQSxPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBQThmUixLQU1JLE1BQUs7QUFOVCxLQU9JLE1BQUs7RUFDRCxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXVFUixLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTDtBQUNBLE1BQU07RUFHRixxQkFBQTtFQUNBLFNBQUE7RUFDQSxnQkFBQTtFQUNBLDhCQUFBO0VBQ0EsY0FBQTtFQUNBLG1CQUFBO0VBQ0EseUJBQUE7RUFDQSxnQkFBQTtFQUNBLG1CQUFBO0VBQ0Esd0JBQUE7RUFDQSw4Q0FBQTs7QUFLSjtFQUNJLHdCQUFBOztBQUtKLEtBQUssYUFBYTtBQUNsQixLQUFLLGFBQWE7QUFDbEIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtBQUNwQixLQUFLLGNBQWM7QUFDbkIsS0FBSyxjQUFjO0FBQ25CLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0FBQ3BCLFFBQVE7QUFDUixRQUFRO0FBQ1IsTUFBTSxVQUFVO0FBQ2hCLE1BQU0sVUFBVTtFQUNaLHlCQUFBO0VBQ0EsMEJBQUE7RUFDQSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0csT0NqbkI2QixrQkRpbkI3Qjs7QUFFSDtFQUNHLE9DcG5CNkIsa0JEb25CN0I7O0FBRUg7RUFDRyxPQ3ZuQjZCLGtCRHVuQjdCOzs7Ozs7Ozs7Ozs7OztBQWlCSDtFQUNJLGVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzQko7RUFDSSxjQUFBO0VBQ0EsZUFBQTs7QUFGSixNQUlJO0VBRUksc0JBQUE7O0FBSVIsaUJBQWtCO0VBQ2QseUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRXBzQko7RUFDRSxhQUFhLGVBQWI7RUFDQSxTQUFTLHdCQUFUO0VBQ0EsU0FBUyxnQ0FBdUMsT0FBTywwQkFDakQsMEJBQWlDLE9BQU8sYUFDeEMseUJBQWdDLE9BQU8saUJBQ3ZDLHlCQUFnQyxPQUFPLE1BSDdDO0VBSUEsbUJBQUE7RUFDQSxrQkFBQTs7QUFnQkY7QUFDQSxDQUFDO0VBQ0MsYUFBYSxlQUFiO0VBQ0EscUJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsY0FBQTtFQUNBLG1DQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9RRixDQUFDLE9BQWlCO0VBQ2hCLHVCQUFBO0VBQ0EsbUJBQUE7RUFDQSxvQkFBQTs7QUFHRixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7QUFDekIsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7O0FBQ3pCLENBQUMsT0FBaUI7RUFBTyxjQUFBOztBQUN6QixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE2RHpCLENBQUMsT0FBaUI7RUFDaEIseUJBQUE7RUFDQSw0QkFBQTtFQUNBLG1CQUFBOztBQUdGLENBQUMsT0FBaUI7RUF6Q2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsYUFBbkI7RUFDSSxlQUFlLGFBQWY7RUFDSSxXQUFXLGFBQVg7O0FBdUNWLENBQUMsT0FBaUI7RUExQ2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsY0FBbkI7RUFDSSxlQUFlLGNBQWY7RUFDSSxXQUFXLGNBQVg7O0FBd0NWLENBQUMsT0FBaUI7RUEzQ2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsY0FBbkI7RUFDSSxlQUFlLGNBQWY7RUFDSSxXQUFXLGNBQVg7O0FBMENWLENBQUMsT0FBaUI7RUF0Q2hCLFFBQVEsa0VBQVI7RUFDQSxtQkFBbUIsWUFBbkI7RUFDSSxlQUFlLFlBQWY7RUFDSSxXQUFXLFlBQVg7O0FBb0NWLENBQUMsT0FBaUI7RUF2Q2hCLFFBQVEsa0VBQVI7RUFDQSxtQkFBbUIsWUFBbkI7RUFDSSxlQUFlLFlBQWY7RUFDSSxXQUFXLFlBQVg7O0FBc0NWLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7RUFDdEIsWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNCRixDQUFDLE9BQWlCO0VBQ2hCLDZDQUFBO0VBQ1EscUNBQUE7O0FBR1YsQ0FBQyxPQUFpQjtFQUNoQix1Q0FBdUMsUUFBdkM7RUFDUSwrQkFBK0IsUUFBL0I7O0FBR1Y7RUFDRTtJQUNFLG1CQUFtQixZQUFuQjtJQUNRLFdBQVcsWUFBWDs7RUFFVjtJQUNFLG1CQUFtQixjQUFuQjtJQUNRLFdBQVcsY0FBWDs7O0FBSVo7RUFDRTtJQUNFLG1CQUFtQixZQUFuQjtJQUNRLFdBQVcsWUFBWDs7RUFFVjtJQUNFLG1CQUFtQixjQUFuQjtJQUNRLFdBQVcsY0FBWDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBOENSLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbGZkLDZFQUFBOztBQXdmQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZmZCw2RUFBQTs7QUE2ZkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1ZmQsNkVBQUE7O0FBa2dCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpnQmQsNkVBQUE7O0FBdWdCQSxDQURILE9BQWlCLEdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRnQmQsNkVBQUE7O0FBNGdCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNnQmQsNkVBQUE7O0FBaWhCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhoQmQsNkVBQUE7O0FBc2hCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJoQmQsNkVBQUE7O0FBMmhCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFoQmQsNkVBQUE7O0FBZ2lCQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvaEJkLDZFQUFBOztBQXFpQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwaUJkLDZFQUFBOztBQTBpQkEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBemlCZCw2RUFBQTs7QUEraUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOWlCZCw2RUFBQTs7QUFvakJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmpCZCw2RUFBQTs7QUF5akJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGpCZCw2RUFBQTs7QUE4akJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdqQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3bUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdm1CZCw2RUFBQTs7QUE2bUJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNW1CZCw2RUFBQTs7QUFrbkJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBam5CZCw2RUFBQTs7QUF1bkJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdG5CZCw2RUFBQTs7QUE0bkJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM25CZCw2RUFBQTs7QUFpb0JBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaG9CZCw2RUFBQTs7QUFzb0JBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcm9CZCw2RUFBQTs7QUEyb0JBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMW9CZCw2RUFBQTs7QUFncEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL29CZCw2RUFBQTs7QUFxcEJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHBCZCw2RUFBQTs7QUEwcEJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenBCZCw2RUFBQTs7QUErcEJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXBCZCw2RUFBQTs7QUFvcUJBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnFCZCw2RUFBQTs7QUF5cUJBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHFCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW10QkEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsdEJkLDZFQUFBOztBQXd0QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2dEJkLDZFQUFBOztBQTZ0QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1dEJkLDZFQUFBOztBQWt1QkEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanVCZCw2RUFBQTs7QUF1dUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHVCZCw2RUFBQTs7QUE0dUJBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN1QmQsNkVBQUE7O0FBaXZCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh2QmQsNkVBQUE7O0FBc3ZCQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ2QmQsNkVBQUE7O0FBMnZCQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF2QmQsNkVBQUE7O0FBZ3dCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS92QmQsNkVBQUE7O0FBcXdCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB3QmQsNkVBQUE7O0FBMHdCQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp3QmQsNkVBQUE7O0FBK3dCQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl3QmQsNkVBQUE7O0FBb3hCQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFueEJkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwekJBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenpCZCw2RUFBQTs7QUErekJBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXpCZCw2RUFBQTs7QUFvMEJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbjBCZCw2RUFBQTs7QUF5MEJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeDBCZCw2RUFBQTs7QUE4MEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNzBCZCw2RUFBQTs7QUFtMUJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDFCZCw2RUFBQTs7QUF3MUJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdjFCZCw2RUFBQTs7QUE2MUJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNTFCZCw2RUFBQTs7QUFrMkJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBajJCZCw2RUFBQTs7QUF1MkJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXQyQmQsNkVBQUE7O0FBNDJCQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTMyQmQsNkVBQUE7O0FBaTNCQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgzQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQSs2QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5NkJkLDZFQUFBOztBQW83QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuN0JkLDZFQUFBOztBQXk3QkEsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4N0JkLDZFQUFBOztBQTg3QkEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3N0JkLDZFQUFBOztBQW04QkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsOEJkLDZFQUFBOztBQXc4QkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2OEJkLDZFQUFBOztBQTY4QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1OEJkLDZFQUFBOztBQWs5QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqOUJkLDZFQUFBOztBQXU5QkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0OUJkLDZFQUFBOztBQTQ5QkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzOUJkLDZFQUFBOztBQWkrQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoK0JkLDZFQUFBOztBQXMrQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyK0JkLDZFQUFBOztBQTIrQkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExK0JkLDZFQUFBOztBQWcvQkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvK0JkLDZFQUFBOztBQXEvQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwL0JkLDZFQUFBOztBQTAvQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6L0JkLDZFQUFBOztBQSsvQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5L0JkLDZFQUFBOztBQW9nQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuZ0NkLDZFQUFBOztBQXlnQ0EsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4Z0NkLDZFQUFBOztBQThnQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3Z0NkLDZFQUFBOztBQW1oQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsaENkLDZFQUFBOztBQXdoQ0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdmhDZCw2RUFBQTs7QUE2aENBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNWhDZCw2RUFBQTs7QUFraUNBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamlDZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFnb0NBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL25DZCw2RUFBQTs7QUFxb0NBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBvQ2QsNkVBQUE7O0FBMG9DQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXpvQ2QsNkVBQUE7O0FBK29DQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5b0NkLDZFQUFBOztBQW9wQ0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucENkLDZFQUFBOztBQXlwQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cENkLDZFQUFBOztBQThwQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3cENkLDZFQUFBOztBQW1xQ0EsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHFDZCw2RUFBQTs7QUF3cUNBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnFDZCw2RUFBQTs7QUE2cUNBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXFDZCw2RUFBQTs7QUFrckNBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpyQ2QsNkVBQUE7O0FBdXJDQSxDQURILE9BQWlCLHNCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0ckNkLDZFQUFBOztBQTRyQ0EsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzckNkLDZFQUFBOztBQWlzQ0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHNDZCw2RUFBQTs7QUFzc0NBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnNDZCw2RUFBQTs7QUEyc0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXNDZCw2RUFBQTs7QUFndENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3NDZCw2RUFBQTs7QUFxdENBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB0Q2QsNkVBQUE7O0FBMHRDQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp0Q2QsNkVBQUE7O0FBK3RDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl0Q2QsNkVBQUE7O0FBb3VDQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW51Q2QsNkVBQUE7O0FBeXVDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4dUNkLDZFQUFBOztBQTh1Q0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3VDZCw2RUFBQTs7QUFtdkNBLENBREgsT0FBaUIsMEJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWx2Q2QsNkVBQUE7O0FBd3ZDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ2Q2QsNkVBQUE7O0FBNnZDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1dkNkLDZFQUFBOztBQWt3Q0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqd0NkLDZFQUFBOztBQXV3Q0EsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHdDZCw2RUFBQTs7QUE0d0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3dDZCw2RUFBQTs7QUFpeENBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh4Q2QsNkVBQUE7O0FBc3hDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ4Q2QsNkVBQUE7O0FBMnhDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF4Q2QsNkVBQUE7O0FBZ3lDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEveENkLDZFQUFBOztBQXF5Q0EsQ0FESCxPQUFpQixzQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHlDZCw2RUFBQTs7QUEweUNBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenlDZCw2RUFBQTs7QUEreUNBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl5Q2QsNkVBQUE7O0FBb3pDQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW56Q2QsNkVBQUE7O0FBeXpDQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4ekNkLDZFQUFBOztBQTh6Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3ekNkLDZFQUFBOztBQW0wQ0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDBDZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBaStDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgrQ2QsNkVBQUE7O0FBcytDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXIrQ2QsNkVBQUE7O0FBMitDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTErQ2QsNkVBQUE7O0FBZy9DQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS8rQ2QsNkVBQUE7O0FBcS9DQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXAvQ2QsNkVBQUE7O0FBMC9DQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXovQ2QsNkVBQUE7O0FBKy9DQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTkvQ2QsNkVBQUE7O0FBb2dEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5nRGQsNkVBQUE7O0FBeWdEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhnRGQsNkVBQUE7O0FBOGdEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdnRGQsNkVBQUE7O0FBbWhEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxoRGQsNkVBQUE7O0FBd2hEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2aERkLDZFQUFBOztBQTZoREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1aERkLDZFQUFBOztBQWtpREEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamlEZCw2RUFBQTs7QUF1aURBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdGlEZCw2RUFBQTs7QUE0aURBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNpRGQsNkVBQUE7O0FBaWpEQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhqRGQsNkVBQUE7O0FBc2pEQSxDQURILE9BQWlCLG1CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyakRkLDZFQUFBOztBQTJqREEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExakRkLDZFQUFBOztBQWdrREEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL2pEZCw2RUFBQTs7QUFxa0RBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcGtEZCw2RUFBQTs7QUEwa0RBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBemtEZCw2RUFBQTs7QUEra0RBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOWtEZCw2RUFBQTs7QUFvbERBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5sRGQsNkVBQUE7O0FBeWxEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhsRGQsNkVBQUE7O0FBOGxEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdsRGQsNkVBQUE7O0FBbW1EQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxtRGQsNkVBQUE7O0FBd21EQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2bURkLDZFQUFBOztBQTZtREEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1bURkLDZFQUFBOztBQWtuREEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqbkRkLDZFQUFBOztBQXVuREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0bkRkLDZFQUFBOztBQTRuREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzbkRkLDZFQUFBOztBQWlvREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFob0RkLDZFQUFBOztBQXNvREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyb0RkLDZFQUFBOztBQTJvREEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExb0RkLDZFQUFBOztBQWdwREEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvb0RkLDZFQUFBOztBQXFwREEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwcERkLDZFQUFBOztBQTBwREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6cERkLDZFQUFBOztBQStwREEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5cERkLDZFQUFBOztBQW9xREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucURkLDZFQUFBOztBQXlxREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cURkLDZFQUFBOztBQThxREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3cURkLDZFQUFBOztBQW1yREEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsckRkLDZFQUFBOztBQXdyREEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2ckRkLDZFQUFBOztBQTZyREEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXJEZCw2RUFBQTs7QUFrc0RBLENBREgsT0FBaUIsd0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpzRGQsNkVBQUE7O0FBdXNEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRzRGQsNkVBQUE7O0FBNHNEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzc0RkLDZFQUFBOztBQWl0REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFodERkLDZFQUFBOztBQXN0REEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnREZCw2RUFBQTs7QUEydERBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXREZCw2RUFBQTs7QUFndURBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3REZCw2RUFBQTs7QUFxdURBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHVEZCw2RUFBQTs7QUEwdURBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp1RGQsNkVBQUE7O0FBK3VEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl1RGQsNkVBQUE7O0FBb3ZEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFudkRkLDZFQUFBOztBQXl2REEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4dkRkLDZFQUFBOztBQTh2REEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3ZEZCw2RUFBQTs7QUFtd0RBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHdEZCw2RUFBQTs7QUF3d0RBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ3RGQsNkVBQUE7O0FBNndEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTV3RGQsNkVBQUE7O0FBa3hEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWp4RGQsNkVBQUE7O0FBdXhEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXR4RGQsNkVBQUE7O0FBNHhEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN4RGQsNkVBQUE7O0FBaXlEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh5RGQsNkVBQUE7O0FBc3lEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyeURkLDZFQUFBOztBQTJ5REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExeURkLDZFQUFBOztBQWd6REEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3lEZCw2RUFBQTs7QUFxekRBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHpEZCw2RUFBQTs7QUEwekRBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenpEZCw2RUFBQTs7QUErekRBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXpEZCw2RUFBQTs7QUFvMERBLENBREgsT0FBaUIscUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW4wRGQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQ3VMSjtFQUNJLHNCQUFBOztBQUdKO0VBQ0ksVUFBQTtFQUNBLFNBQUE7RUFDQSw2QkFBQTtFQUNBLGVBQUE7O0FBRUEsa0JBQUM7RUFDRywyQkFBQTtFQUNBLG1CQUFBOztBTHhMSixtQkFBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBOztBQUVKLE9BQVE7RUFDSixPQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBS3lOUjtFQUNJLGNBQUE7RUh4TkEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGdCQUFBOztBQUNBLE9BQVE7RUFDSiw4QkFBQTs7QUd3TlI7RUFDSSxjQUFBO0VIdFBBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFR3NQQSxrQkFBQTtFQUNBLHVCQUFBOztBSHJQQSxnQkFBRTtBQUNGLGdCQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUNBLE9BQVEsaUJBZk47QUFlRixPQUFRLGlCQWROO0VBZUUsNkJBQUE7O0FBWEosZ0JBQUU7QUFDRixnQkFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxpQkE1Qk47QUE0QkYsT0FBUSxpQkEzQk47RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FHMlFSO0FBQ0E7RUFDSSwyQkFBQTs7QUFHSjtFQUNJLFdBQVcsY0FBWDs7QUFHSixxQkFBc0I7RUFDbEIsV0FBVyxTQUFYOztBQUdKLHFCQUFzQjtFQUNsQixXQUFXLGVBQVg7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBK0NKO0VBQ0ksY0FBQTs7QUw5VkEsa0JBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7QUs2VkosTUFBTTtFQUNGLFdBQUE7RUFDQSxnQkFBQTs7QUFJUjtFQUNJLHdCQUFBOztBQUdKO0VBQ0ksV0FBQTs7QUFHSjtFQUNJLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXFCSjtFQUNJLHNCQUFBO0VBQ0EsbUJBQUE7O0FBRUEsbUJBQUM7QUFDRCxtQkFBQztFQUNHLG1CQUFBOztBQU5SLG1CQVNJO0VBQ0ksb0JBQUE7O0FBVlIsbUJBY0k7RUFFSSxxQkFBQTs7QUFLQSxtQkFQSixvQkFPSztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1TVo7RUFDSSxzQkFBQTs7QUFHSjtFQUNJLGtDQUFBO0VBRUEsZ0NBQUE7RUFDQSxtQkFBQTtFQUNBLGNBQUE7RUhobUJBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQTJHQSxtQkFBQTtFQUNBLHlCQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBO0VHK2VBLGdCQUFBOztBSC9sQkEsT0FBUTtFQUNKLDhCQUFBOztBR2ltQlIsaUJBQWtCO0VBQ2QsZ0NBQUE7RUFDQSxnQkFBQTtFQUNBLG1CQUFBOztBQUdKLGlCQUFrQjtFSHBuQmQscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGdCQUFBO0VBMkdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSx1QkFBQTtFR3VnQkEsZ0JBQUE7O0FIbm5CQSxPQUFRLGtCR2luQk07RUhobkJWLDhCQUFBOztBR3FuQlIsaUJBQWtCO0VBQ2QsZ0JBQUEifQ== */
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1jc3Mvbm9ybWFsaXplLmNzcyIsIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1sZWdhY3ktYWRkb24vbm9ybWFsaXplLWxlZ2FjeS1hZGRvbi5jc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtdXRpbGl0aWVzLmxlc3MiLCIvc3JjL3ZlbmRvci9jZi1jb3JlL3NyYy9jZi11dGlsaXRpZXMubGVzcyIsIi8uLi9jZi1jb3JlL3NyYy9jZi1tZWRpYS1xdWVyaWVzLmxlc3MiLCIvc3JjL3ZlbmRvci9jZi1jb3JlL3NyYy9jZi1tZWRpYS1xdWVyaWVzLmxlc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtYmFzZS5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtY29yZS9zcmMvY2YtYmFzZS5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtY29yZS9zcmMvY2YtdmFycy5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtaWNvbnMvc3JjL2NmLWljb25zLmxlc3MiLCIvc3JjL2NmLWV4cGFuZGFibGVzLmxlc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7OztBQVFBO0VBQ0UsdUJBQUE7O0VBQ0EsMEJBQUE7O0VBQ0EsOEJBQUE7Ozs7OztBQU9GO0VBQ0UsU0FBQTs7Ozs7Ozs7OztBQWFGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7QUFDQTtBQUNBO0FBQ0E7RUFDRSxxQkFBQTs7RUFDQSx3QkFBQTs7Ozs7OztBQVFGLEtBQUssSUFBSTtFQUNQLGFBQUE7RUFDQSxTQUFBOzs7Ozs7QUFRRjtBQUNBO0VBQ0UsYUFBQTs7Ozs7OztBQVVGO0VBQ0UsNkJBQUE7Ozs7OztBQVFGLENBQUM7QUFDRCxDQUFDO0VBQ0MsVUFBQTs7Ozs7OztBQVVGLElBQUk7RUFDRix5QkFBQTs7Ozs7QUFPRjtBQUNBO0VBQ0UsaUJBQUE7Ozs7O0FBT0Y7RUFDRSxrQkFBQTs7Ozs7O0FBUUY7RUFDRSxjQUFBO0VBQ0EsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSxnQkFBQTtFQUNBLFdBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7RUFDRSxjQUFBO0VBQ0EsY0FBQTtFQUNBLGtCQUFBO0VBQ0Esd0JBQUE7O0FBR0Y7RUFDRSxXQUFBOztBQUdGO0VBQ0UsZUFBQTs7Ozs7OztBQVVGO0VBQ0UsU0FBQTs7Ozs7QUFPRixHQUFHLElBQUk7RUFDTCxnQkFBQTs7Ozs7OztBQVVGO0VBQ0UsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSx1QkFBQTtFQUNBLFNBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsaUNBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7OztBQWtCRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7RUFDQSxhQUFBOztFQUNBLFNBQUE7Ozs7OztBQU9GO0VBQ0UsaUJBQUE7Ozs7Ozs7O0FBVUY7QUFDQTtFQUNFLG9CQUFBOzs7Ozs7Ozs7QUFXRjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0gsMEJBQUE7O0VBQ0EsZUFBQTs7Ozs7O0FBT0YsTUFBTTtBQUNOLElBQUssTUFBSztFQUNSLGVBQUE7Ozs7O0FBT0YsTUFBTTtBQUNOLEtBQUs7RUFDSCxTQUFBO0VBQ0EsVUFBQTs7Ozs7O0FBUUY7RUFDRSxtQkFBQTs7Ozs7Ozs7O0FBV0YsS0FBSztBQUNMLEtBQUs7RUFDSCxzQkFBQTs7RUFDQSxVQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsWUFBQTs7Ozs7O0FBUUYsS0FBSztFQUNILDZCQUFBOztFQUNBLHVCQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsd0JBQUE7Ozs7O0FBT0Y7RUFDRSx5QkFBQTtFQUNBLGFBQUE7RUFDQSw4QkFBQTs7Ozs7O0FBUUY7RUFDRSxTQUFBOztFQUNBLFVBQUE7Ozs7OztBQU9GO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7RUFDRSxpQkFBQTs7Ozs7OztBQVVGO0VBQ0UseUJBQUE7RUFDQSxpQkFBQTs7QUFHRjtBQUNBO0VBQ0UsVUFBQTs7Ozs7Ozs7O0FDNVpGO0FBQ0E7QUFDQTtFQUNJLGdCQUFBO0VBQ0EsUUFBQTs7Ozs7Ozs7O0FBWUo7RUFDSSxlQUFBOzs7Ozs7QUFRSjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksdUJBQUE7Ozs7Ozs7Ozs7QUFhSjtFQUNJLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsYUFBQTs7QUFHSjtFQUNJLGNBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7Ozs7O0FBT0o7QUFDQTtFQUNJLGFBQUE7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSxjQUFjLHdCQUFkOzs7OztBQU9KO0VBQ0ksZ0JBQUE7RUFDQSxxQkFBQTs7Ozs7QUFPSjtFQUNJLFlBQUE7Ozs7O0FBT0osQ0FBQztBQUNELENBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxhQUFBOzs7Ozs7OztBQVdKO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtFQUNJLGtCQUFBOzs7OztBQU9KO0FBQ0E7QUFDQTtFQUNJLG1CQUFBOzs7OztBQU9KLEdBQUk7QUFDSixHQUFJO0VBQ0EsZ0JBQUE7RUFDQSxzQkFBQTs7Ozs7Ozs7QUFXSjtFQUNJLCtCQUFBOzs7Ozs7OztBQVdKO0VBQ0ksU0FBQTs7Ozs7OztBQVNKO0VBQ0ksU0FBQTs7RUFDQSxtQkFBQTs7RUFDQSxrQkFBQTs7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSx3QkFBQTtFQUNBLHVCQUFBOzs7Ozs7QUFRSjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0Qsa0JBQUE7Ozs7OztBQVFKLEtBQUs7QUFDTCxLQUFLO0VBQ0QsYUFBQTtFQUNBLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDOU1BLE1BQU87RUFDSCx3QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF5QkosV0FBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBOztBQUVKLE9BQVE7RUFDSixPQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMEJSO0VBQ0Usa0JBQUE7RUFDQSxVQUFBO0VBQ0EsV0FBQTtFQUNBLFNBQUE7RUFDQSxZQUFBO0VBQ0EsVUFBQTtFQUNBLGdCQUFBO0VBQ0EsTUFBTSxhQUFOOzs7Ozs7Ozs7Ozs7OztBQWlCRjtFQUNJLHFCQUFBOztBQUNBLE9BQVE7RUFFSixlQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXdCUjtFQUNJLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9DSjtFQUNJLHFCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFtSEo7RUNMSSxrQkFBQTtFQUNBLHNCQUFBO0VBQ0EsU0FBQTs7QURPSjtFQUNJLGtCQUFBO0VBQ0EsTUFBQTtFQUNBLE9BQUE7RUFDQSxXQUFBO0VBQ0EsWUFBQTs7QUFHSjtFQ2pCSSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsU0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QURvTko7RUFBVSx3QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsMEJBQUE7O0FBQ1Y7RUFBVSw2QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwRFY7RUFBYSxXQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxtQkFBQTs7QUFDYjtFQUFhLG1CQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRWpnQmIscUJBSDBDO0VBRzFDO0lGd2lCUSxhQUFBOzs7QUd4aUJSLHFCQUgwQztFQUcxQztJSHdpQlEsYUFBQTs7O0FBSVI7RUFDSSxhQUFBOztBRTdpQkoscUJBSDBDO0VBRzFDO0lGK2lCUSxjQUFBOzs7QUcvaUJSLHFCQUgwQztFQUcxQztJSCtpQlEsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFtRFI7RUNIRSxrQkFBQTs7QURPRjtFQ1BFLGtCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FHeGlCRjtFQUNJLGNBQUE7RUFDQSxzQkFBc0Isd0JBQXRCO0VBQ0EsZUFBQTtFQUNBLGtCQUFBOztBQThESjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDSSxhQUFBOztBQUdKO0FBQ0E7RUN4S0kscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBcUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURyR0EsRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRGxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEcUlKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7RUFDUCx3QkFBQTs7QUY5SVIscUJBSDBDO0VBRzFDO0VBQUE7SUdyQ0kscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBO0lBOEdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUQ5R0EsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRGxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbUpBLENBQUU7RUFBRixDQUFFO0VBQ0YsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsTUFBTztFQUFQLE1BQU87RUFDUCxHQUFJO0VBQUosR0FBSTtFQUNKLEtBQU07RUFBTixLQUFNO0VBQ04sVUFBVztFQUFYLFVBQVc7SUFDUCx3QkFBQTs7RUFHSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtJQUNBLHdCQUFBOzs7QUR6S1oscUJBSDBDO0VBRzFDO0VBQUE7SUVyQ0kscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBO0lBOEdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUQ5R0EsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRGxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbUpBLENBQUU7RUFBRixDQUFFO0VBQ0YsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsTUFBTztFQUFQLE1BQU87RUFDUCxHQUFJO0VBQUosR0FBSTtFQUNKLEtBQU07RUFBTixLQUFNO0VBQ04sVUFBVztFQUFYLFVBQVc7SUFDUCx3QkFBQTs7RUFHSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtJQUNBLHdCQUFBOzs7QUFLWjtBQUNBO0VDcE5JLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQThHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEOUdBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRGlMSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0VBQ1Asd0JBQUE7O0FBR0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUZ2TVIscUJBSDBDO0VBRzFDO0VBQUE7SUdyQ0kscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBO0lBdUhBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUR2SEEsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRGxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VENE1BLENBQUU7RUFBRixDQUFFO0VBQ0YsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsTUFBTztFQUFQLE1BQU87RUFDUCxHQUFJO0VBQUosR0FBSTtFQUNKLEtBQU07RUFBTixLQUFNO0VBQ04sVUFBVztFQUFYLFVBQVc7SUFDUCx3QkFBQTs7O0FEck5aLHFCQUgwQztFQUcxQztFQUFBO0lFckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQXVIQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEdkhBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRDRNQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7OztBQUtaO0FBQ0E7RUNoUUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBdUhBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUR2SEEsRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRGxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FENk5KLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBRmhQUixxQkFIMEM7RUFHMUM7RUFBQTtJR1pJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQXVHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEeEdBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RURESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBRlFSLHFCQUgwQztFQUcxQztFQUFBO0lFWkkscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGdCQUFBO0lBdUdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUR4R0EsT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFRERKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7O0FEZ1FSO0FBQ0E7RUNyUUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGdCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUR4R0EsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBRERKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURvUUosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztBQUNYLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FBSVI7QUFDQTtFQ3RSSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUF1R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsaUJBQUE7RUFDQSx5QkFBQTs7QUQxR0EsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBRERKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURxUkosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztBQUNYLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FBSVI7QUFDQTtFQ2hUSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUFrSEEscUJBQUE7RUFDQSxpQkFBQTtFQUNBLG1CQUFBO0VBQ0EsaUJBQUE7RUFDQSx5QkFBQTs7QURySEEsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBRERKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUQrU0osQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztBQUNYLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0EsaUJBQUE7O0FBSVI7QUFjQTtBQ0FBO0VBelhJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXVIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RURtUEEsd0JBQUE7RUFDQSwyQkFBQTs7QUEzV0EsZUFBRTtBQUNGLGVBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGdCRGZOO0FDZUYsT0FBUSxnQkRkTjtFQ2VFLDZCQUFBOztBRFhKLGVBQUU7QUFDRixlQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGdCQTVCTjtBQTRCRixPQUFRLGdCQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLGdCRDVCTjtBQzRCRixPQUFRLGdCRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osZUFBRTtBQUNGLGVBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxnQkNmTjtBRGVGLE9BQVEsZ0JDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLGdCQWZOO0FBZUYsT0FBUSxnQkFkTjtFQWVFLDZCQUFBOztBQVhKLGVBQUU7QUFDRixlQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGdCQzVCTjtBRDRCRixPQUFRLGdCQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGdCQTVCTjtBQTRCRixPQUFRLGdCQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osZUFBRTtBQUNGLGVBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGdCRGZOO0FDZUYsT0FBUSxnQkRkTjtFQ2VFLDZCQUFBOztBRFhKLGVBQUU7QUFDRixlQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGdCQTVCTjtBQTRCRixPQUFRLGdCQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLGdCRDVCTjtBQzRCRixPQUFRLGdCRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osZUFBRTtBQUNGLGVBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxnQkNmTjtBRGVGLE9BQVEsZ0JDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLGdCQWZOO0FBZUYsT0FBUSxnQkFkTjtFQWVFLDZCQUFBOztBQVhKLGVBQUU7QUFDRixlQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGdCQzVCTjtBRDRCRixPQUFRLGdCQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGdCQTVCTjtBQTRCRixPQUFRLGdCQTNCTjtFQTRCRSw4QkFBQTs7QUhEUixxQkFIMEM7RUFHMUM7RUVvVkE7RUNBQTtJRE5RLHdCQUFBO0lBQ0Esa0JBQUE7OztBRC9VUixxQkFIMEM7RUFHMUM7RUNvVkE7RUNBQTtJRE5RLHdCQUFBO0lBQ0Esa0JBQUE7OztBQVNSO0FBWUE7QUNBQTtFQXpZSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RURpWUEsMkJBQUE7RUFDQSxjQUFBO0VBQ0EsaUJBQUE7O0FBallBLGFBQUU7QUFDRixhQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsY0FmTjtBQWVGLE9BQVEsY0FkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsY0RmTjtBQ2VGLE9BQVEsY0RkTjtFQ2VFLDZCQUFBOztBRFhKLGFBQUU7QUFDRixhQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGNBNUJOO0FBNEJGLE9BQVEsY0EzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxjRDVCTjtBQzRCRixPQUFRLGNEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixhQUFFO0FBQ0YsYUFBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGNDZk47QURlRixPQUFRLGNDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLGNBZk47QUFlRixPQUFRLGNBZE47RUFlRSw2QkFBQTs7QUFYSixhQUFFO0FBQ0YsYUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxjQzVCTjtBRDRCRixPQUFRLGNDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsY0E1Qk47QUE0QkYsT0FBUSxjQTNCTjtFQTRCRSw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FEK1hSO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTtFQUNBLHVCQUFBOztBQUdKLENBQUU7QUFDRixDQUFFO0VBQ0UscUJBQUE7O0FBR0osSUFBSSxLQUFNO0VBQ04sb0JBQUE7O0FBSUosT0FBUSxJQUFJO0VBQ1IsZ0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQThCSjtFQUNJLGVBQUE7RUFDQSxvQkFBQTtFQUNBLHFCQUFBO0VBQ0EsY0FBQTtFQUNBLHFCQUFBOztBQUVBLENBQUM7QUFDRCxDQUFDO0VBQ0cscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7O0FBR0osQ0FBQztBQUNELENBQUM7RUFDRyxtQkFBQTtFQUNBLG9CQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNFUixDQUtJO0FBSkosRUFJSTtBQUhKLEVBR0k7RUFDSSx3QkFBQTs7QUFJUixHQUFJO0VBRUEsc0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE0Qko7RUFHSSxpQkFBQTtFQUNBLGtCQUFBOztBQUlKO0VBQ0ksc0JBQUE7O0FBREosRUFHSTtFQUNJLHNCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBeUNSO0VDMXBCSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FERUEsS0FBRTtBQUNGLEtBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxNRGZOO0FDZUYsT0FBUSxNRGROO0VDZUUsNkJBQUE7O0FEWEosS0FBRTtBQUNGLEtBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLE1ENUJOO0FDNEJGLE9BQVEsTUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEtBQUU7QUFDRixLQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUNmTjtBRGVGLE9BQVEsTUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQVhKLEtBQUU7QUFDRixLQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1DNUJOO0FENEJGLE9BQVEsTUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBRHduQlI7QUFDQTtFQUNJLGdCQUFBOztBQUVBLEtBQU07QUFBTixLQUFNO0VBQ0YsY0FBQTtFQUNBLG1CQUFBO0VDbG9CSixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUF1R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsaUJBQUE7RUFDQSx5QkFBQTs7QUQxR0EsT0FBUSxNQTZuQkY7QUE3bkJOLE9BQVEsTUE2bkJGO0VBNW5CRiw4QkFBQTs7QUNESixPQUFRLE1ENm5CRjtBQzduQk4sT0FBUSxNRDZuQkY7RUM1bkJGLDhCQUFBOztBRERKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FDREosT0FBUSxNRDZuQkY7QUM3bkJOLE9BQVEsTUQ2bkJGO0VDNW5CRiw4QkFBQTs7QURxUkosQ0FBRSxRQXVXSTtBQXZXTixDQUFFLFFBdVdJO0FBdFdOLEVBQUcsUUFzV0c7QUF0V04sRUFBRyxRQXNXRztBQXJXTixFQUFHLFFBcVdHO0FBcldOLEVBQUcsUUFxV0c7QUFwV04sRUFBRyxRQW9XRztBQXBXTixFQUFHLFFBb1dHO0FBbldOLE1BQU8sUUFtV0Q7QUFuV04sTUFBTyxRQW1XRDtBQWxXTixHQUFJLFFBa1dFO0FBbFdOLEdBQUksUUFrV0U7QUFqV04sS0FBTSxRQWlXQTtBQWpXTixLQUFNLFFBaVdBO0FBaFdOLFVBQVcsUUFnV0w7QUFoV04sVUFBVyxRQWdXTDtBQS9WTixFQUFHLFFBK1ZHO0FBL1ZOLEVBQUcsUUErVkc7QUE5Vk4sR0FBSSxRQThWRTtBQTlWTixHQUFJLFFBOFZFO0FBN1ZOLEVBQUcsUUE2Vkc7QUE3Vk4sRUFBRyxRQTZWRztBQTVWTixHQUFJLFFBNFZFO0FBNVZOLEdBQUksUUE0VkU7QUEzVk4sRUFBRyxRQTJWRztBQTNWTixFQUFHLFFBMlZHO0FBMVZOLEdBQUksUUEwVkU7QUExVk4sR0FBSSxRQTBWRTtBQXpWTixFQUFHLFFBeVZHO0FBelZOLEVBQUcsUUF5Vkc7QUF4Vk4sR0FBSSxRQXdWRTtBQXhWTixHQUFJLFFBd1ZFO0FBdlZOLEVBQUcsUUF1Vkc7QUF2Vk4sRUFBRyxRQXVWRztBQXRWTixHQUFJLFFBc1ZFO0FBdFZOLEdBQUksUUFzVkU7RUFyVkYsd0JBQUE7O0FBeFNKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FDREosT0FBUSxNRDZuQkY7QUM3bkJOLE9BQVEsTUQ2bkJGO0VDNW5CRiw4QkFBQTs7QURESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUQ2bkJGO0FDN25CTixPQUFRLE1ENm5CRjtFQzVuQkYsOEJBQUE7O0FBcVJKLENBQUUsUUR1V0k7QUN2V04sQ0FBRSxRRHVXSTtBQ3RXTixFQUFHLFFEc1dHO0FDdFdOLEVBQUcsUURzV0c7QUNyV04sRUFBRyxRRHFXRztBQ3JXTixFQUFHLFFEcVdHO0FDcFdOLEVBQUcsUURvV0c7QUNwV04sRUFBRyxRRG9XRztBQ25XTixNQUFPLFFEbVdEO0FDbldOLE1BQU8sUURtV0Q7QUNsV04sR0FBSSxRRGtXRTtBQ2xXTixHQUFJLFFEa1dFO0FDaldOLEtBQU0sUURpV0E7QUNqV04sS0FBTSxRRGlXQTtBQ2hXTixVQUFXLFFEZ1dMO0FDaFdOLFVBQVcsUURnV0w7QUMvVk4sRUFBRyxRRCtWRztBQy9WTixFQUFHLFFEK1ZHO0FDOVZOLEdBQUksUUQ4VkU7QUM5Vk4sR0FBSSxRRDhWRTtBQzdWTixFQUFHLFFENlZHO0FDN1ZOLEVBQUcsUUQ2Vkc7QUM1Vk4sR0FBSSxRRDRWRTtBQzVWTixHQUFJLFFENFZFO0FDM1ZOLEVBQUcsUUQyVkc7QUMzVk4sRUFBRyxRRDJWRztBQzFWTixHQUFJLFFEMFZFO0FDMVZOLEdBQUksUUQwVkU7QUN6Vk4sRUFBRyxRRHlWRztBQ3pWTixFQUFHLFFEeVZHO0FDeFZOLEdBQUksUUR3VkU7QUN4Vk4sR0FBSSxRRHdWRTtBQ3ZWTixFQUFHLFFEdVZHO0FDdlZOLEVBQUcsUUR1Vkc7QUN0Vk4sR0FBSSxRRHNWRTtBQ3RWTixHQUFJLFFEc1ZFO0VDclZGLHdCQUFBOztBRDRWUjtBQUNBLEtBQU07RUFDRixnQ0FBQTs7QUFHSjtFQzVvQkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VENG9CQSxnQkFBQTs7QUEzb0JBLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0VBQ0osOEJBQUE7O0FENm9CUixLQUFNO0VDbnJCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FERUEsS0ErcUJFLEdBL3FCQTtBQUNGLEtBOHFCRSxHQTlxQkE7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQWdxQk4sR0EvcUJBO0FBZUYsT0FBUSxNQWdxQk4sR0E5cUJBO0VBZUUsNkJBQUE7O0FDREosT0FBUSxNRGdxQk4sR0EvcUJBO0FDZUYsT0FBUSxNRGdxQk4sR0E5cUJBO0VDZUUsNkJBQUE7O0FEWEosS0EwcUJFLEdBMXFCQTtBQUNGLEtBeXFCRSxHQXpxQkE7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUE4b0JOLEdBMXFCQTtBQTRCRixPQUFRLE1BOG9CTixHQXpxQkE7RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDhvQk4sR0ExcUJBO0FDNEJGLE9BQVEsTUQ4b0JOLEdBenFCQTtFQzRCRSw4QkFBQTs7QUFsQ0osS0QrcUJFLEdDL3FCQTtBQUNGLEtEOHFCRSxHQzlxQkE7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQWdxQk4sR0MvcUJBO0FEZUYsT0FBUSxNQWdxQk4sR0M5cUJBO0VEZUUsNkJBQUE7O0FDREosT0FBUSxNRGdxQk4sR0MvcUJBO0FBZUYsT0FBUSxNRGdxQk4sR0M5cUJBO0VBZUUsNkJBQUE7O0FBWEosS0QwcUJFLEdDMXFCQTtBQUNGLEtEeXFCRSxHQ3pxQkE7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUE4b0JOLEdDMXFCQTtBRDRCRixPQUFRLE1BOG9CTixHQ3pxQkE7RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxNRDhvQk4sR0MxcUJBO0FBNEJGLE9BQVEsTUQ4b0JOLEdDenFCQTtFQTRCRSw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FEMnFCUjtFQUNJLHNCQUFBO0VBQ0EscUJBQUE7O0FGcnJCSixxQkFIMEM7RUFHMUM7SUV3ckJRLHFCQUFBO0lBQ0Esb0JBQUE7OztBRHpyQlIscUJBSDBDO0VBRzFDO0lDd3JCUSxxQkFBQTtJQUNBLG9CQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBNEJSO0VBQ0ksY0FBQTtFQUVBLHVCQUFBO0VDdHZCQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FERUEsS0FBRTtBQUNGLEtBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxNRGZOO0FDZUYsT0FBUSxNRGROO0VDZUUsNkJBQUE7O0FEWEosS0FBRTtBQUNGLEtBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLE1ENUJOO0FDNEJGLE9BQVEsTUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEtBQUU7QUFDRixLQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUNmTjtBRGVGLE9BQVEsTUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQVhKLEtBQUU7QUFDRixLQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1DNUJOO0FENEJGLE9BQVEsTUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBRDZzQlIsS0FNSSxNQUFLO0FBTlQsS0FPSSxNQUFLO0VBQ0QscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1RVIsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0w7QUFDQSxNQUFNO0VBR0YscUJBQUE7RUFDQSxTQUFBO0VBQ0EsZ0JBQUE7RUFDQSw4QkFBQTtFQUNBLGNBQUE7RUFDQSxtQkFBQTtFQUNBLHlCQUFBO0VBQ0EsZ0JBQUE7RUFDQSxtQkFBQTtFQUNBLHdCQUFBO0VBQ0EsOENBQUE7O0FBS0o7RUFDSSx3QkFBQTs7QUFLSixLQUFLLGFBQWE7QUFDbEIsS0FBSyxhQUFhO0FBQ2xCLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxjQUFjO0FBQ25CLEtBQUssY0FBYztBQUNuQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtBQUNwQixRQUFRO0FBQ1IsUUFBUTtBQUNSLE1BQU0sVUFBVTtBQUNoQixNQUFNLFVBQVU7RUFDWix5QkFBQTtFQUNBLDBCQUFBO0VBQ0EsaUJBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNHLE9FaDBCNkIsa0JGZzBCN0I7O0FBRUg7RUFDRyxPRW4wQjZCLGtCRm0wQjdCOztBQUVIO0VBQ0csT0V0MEI2QixrQkZzMEI3Qjs7Ozs7Ozs7Ozs7Ozs7QUFpQkg7RUFDSSxlQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBc0JKO0VBQ0ksY0FBQTtFQUNBLGVBQUE7O0FBRkosTUFJSTtFQUVJLHNCQUFBOztBQUlSLGlCQUFrQjtFQUNkLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FIMTdCQSxNQUFPO0VBQ0gsd0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBeUJKLFdBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBCUjtFQUNFLGtCQUFBO0VBQ0EsVUFBQTtFQUNBLFdBQUE7RUFDQSxTQUFBO0VBQ0EsWUFBQTtFQUNBLFVBQUE7RUFDQSxnQkFBQTtFQUNBLE1BQU0sYUFBTjs7Ozs7Ozs7Ozs7Ozs7QUFpQkY7RUFDSSxxQkFBQTs7QUFDQSxPQUFRO0VBRUosZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3QlI7RUFDSSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvQ0o7RUFDSSxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbUhKO0VBTEksa0JBQUE7RUFDQSxzQkFBQTtFQUNBLFNBQUE7O0FBT0o7RUFDSSxrQkFBQTtFQUNBLE1BQUE7RUFDQSxPQUFBO0VBQ0EsV0FBQTtFQUNBLFlBQUE7O0FBR0o7RUFqQkksa0JBQUE7RUFDQSxtQkFBQTtFQUNBLFNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb05KO0VBQVUsd0JBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDBCQUFBOztBQUNWO0VBQVUsNkJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMERWO0VBQWEsV0FBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsbUJBQUE7O0FBQ2I7RUFBYSxtQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUNqZ0JiLHFCQUgwQztFQUcxQztJRHdpQlEsYUFBQTs7O0FFeGlCUixxQkFIMEM7RUFHMUM7SUZ3aUJRLGFBQUE7OztBQUlSO0VBQ0ksYUFBQTs7QUM3aUJKLHFCQUgwQztFQUcxQztJRCtpQlEsY0FBQTs7O0FFL2lCUixxQkFIMEM7RUFHMUM7SUYraUJRLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbURSO0VBSEUsa0JBQUE7O0FBT0Y7RUFQRSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBSXhpQkY7RUFDSSxjQUFBO0VBQ0Esc0JBQXNCLHdCQUF0QjtFQUNBLGVBQUE7RUFDQSxrQkFBQTs7QUE4REo7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtBQUNBO0VBeEtJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEckdBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQXFJSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0VBQ1Asd0JBQUE7O0FIOUlSLHFCQUgwQztFQUcxQztFQUFBO0lHckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQThHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEOUdBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQW1KQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7O0VBR0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7SUFDQSx3QkFBQTs7O0FGektaLHFCQUgwQztFQUcxQztFQUFBO0lFckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQThHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEOUdBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQW1KQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7O0VBR0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7SUFDQSx3QkFBQTs7O0FBS1o7QUFDQTtFQXBOSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUE4R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRDlHQSxFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUFpTEosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztFQUNQLHdCQUFBOztBQUdKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FIdk1SLHFCQUgwQztFQUcxQztFQUFBO0lHckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQXVIQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEdkhBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQTRNQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7OztBRnJOWixxQkFIMEM7RUFHMUM7RUFBQTtJRXJDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUF1SEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHZIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUE0TUEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOzs7QUFLWjtBQUNBO0VBaFFJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXVIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEdkhBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQTZOSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUhoUFIscUJBSDBDO0VBRzFDO0VBQUE7SUdaSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUF1R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHhHQSxPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VEREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOzs7QUZRUixxQkFIMEM7RUFHMUM7RUFBQTtJRVpJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQXVHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEeEdBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RURESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBQWdRUjtBQUNBO0VBclFJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEeEdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBb1FKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBQUlSO0FBQ0E7RUF0UkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEMUdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBcVJKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBQUlSO0FBQ0E7RUFoVEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBa0hBLHFCQUFBO0VBQ0EsaUJBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEckhBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FBK1NKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLGlCQUFBOztBQUlSO0FEY0E7QUNBQTtFQXpYSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUF1SEEsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBbVBBLHdCQUFBO0VBQ0EsMkJBQUE7O0FEM1dBLGVBQUU7QUFDRixlQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxnQkRmTjtBQ2VGLE9BQVEsZ0JEZE47RUNlRSw2QkFBQTs7QURYSixlQUFFO0FBQ0YsZUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxnQkQ1Qk47QUM0QkYsT0FBUSxnQkQzQk47RUM0QkUsOEJBQUE7O0FBbENKLGVBQUU7QUFDRixlQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JDZk47QURlRixPQUFRLGdCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUFYSixlQUFFO0FBQ0YsZUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkM1Qk47QUQ0QkYsT0FBUSxnQkMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FEbENKLGVBQUU7QUFDRixlQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxnQkRmTjtBQ2VGLE9BQVEsZ0JEZE47RUNlRSw2QkFBQTs7QURYSixlQUFFO0FBQ0YsZUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxnQkQ1Qk47QUM0QkYsT0FBUSxnQkQzQk47RUM0QkUsOEJBQUE7O0FBbENKLGVBQUU7QUFDRixlQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JDZk47QURlRixPQUFRLGdCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUFYSixlQUFFO0FBQ0YsZUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkM1Qk47QUQ0QkYsT0FBUSxnQkMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FIRFIscUJBSDBDO0VBRzFDO0VFb1ZBO0VDQUE7SUFOUSx3QkFBQTtJQUNBLGtCQUFBOzs7QUYvVVIscUJBSDBDO0VBRzFDO0VDb1ZBO0VDQUE7SUFOUSx3QkFBQTtJQUNBLGtCQUFBOzs7QUFTUjtBRFlBO0FDQUE7RUF6WUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBaVlBLDJCQUFBO0VBQ0EsY0FBQTtFQUNBLGlCQUFBOztBRGpZQSxhQUFFO0FBQ0YsYUFBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGNBZk47QUFlRixPQUFRLGNBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGNEZk47QUNlRixPQUFRLGNEZE47RUNlRSw2QkFBQTs7QURYSixhQUFFO0FBQ0YsYUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxjQTVCTjtBQTRCRixPQUFRLGNBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsY0Q1Qk47QUM0QkYsT0FBUSxjRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osYUFBRTtBQUNGLGFBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxjQ2ZOO0FEZUYsT0FBUSxjQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxjQWZOO0FBZUYsT0FBUSxjQWROO0VBZUUsNkJBQUE7O0FBWEosYUFBRTtBQUNGLGFBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsY0M1Qk47QUQ0QkYsT0FBUSxjQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGNBNUJOO0FBNEJGLE9BQVEsY0EzQk47RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQStYUjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNJLGFBQUE7RUFDQSx1QkFBQTs7QUFHSixDQUFFO0FBQ0YsQ0FBRTtFQUNFLHFCQUFBOztBQUdKLElBQUksS0FBTTtFQUNOLG9CQUFBOztBQUlKLE9BQVEsSUFBSTtFQUNSLGdCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE4Qko7RUFDSSxlQUFBO0VBQ0Esb0JBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7RUFDQSxxQkFBQTs7QUFFQSxDQUFDO0FBQ0QsQ0FBQztFQUNHLHFCQUFBO0VBQ0EsY0FBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxvQkFBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzRVIsQ0FLSTtBQUpKLEVBSUk7QUFISixFQUdJO0VBQ0ksd0JBQUE7O0FBSVIsR0FBSTtFQUVBLHNCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBNEJKO0VBR0ksaUJBQUE7RUFDQSxrQkFBQTs7QUFJSjtFQUNJLHNCQUFBOztBQURKLEVBR0k7RUFDSSxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXlDUjtFQTFwQkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBQUU7QUFDRixLQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURmTjtBQ2VGLE9BQVEsTURkTjtFQ2VFLDZCQUFBOztBRFhKLEtBQUU7QUFDRixLQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDVCTjtBQzRCRixPQUFRLE1EM0JOO0VDNEJFLDhCQUFBOztBQWxDSixLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZk47QURlRixPQUFRLE1DZE47RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzVCTjtBRDRCRixPQUFRLE1DM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUF3bkJSO0FBQ0E7RUFDSSxnQkFBQTs7QUFFQSxLQUFNO0FBQU4sS0FBTTtFQUNGLGNBQUE7RUFDQSxtQkFBQTtFQWxvQkoscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEMUdBLE9BQVEsTUM2bkJGO0FEN25CTixPQUFRLE1DNm5CRjtFRDVuQkYsOEJBQUE7O0FDREosT0FBUSxNQTZuQkY7QUE3bkJOLE9BQVEsTUE2bkJGO0VBNW5CRiw4QkFBQTs7QURESixPQUFRLE1DNm5CRjtBRDduQk4sT0FBUSxNQzZuQkY7RUQ1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FEcVJKLENBQUUsUUN1V0k7QUR2V04sQ0FBRSxRQ3VXSTtBRHRXTixFQUFHLFFDc1dHO0FEdFdOLEVBQUcsUUNzV0c7QURyV04sRUFBRyxRQ3FXRztBRHJXTixFQUFHLFFDcVdHO0FEcFdOLEVBQUcsUUNvV0c7QURwV04sRUFBRyxRQ29XRztBRG5XTixNQUFPLFFDbVdEO0FEbldOLE1BQU8sUUNtV0Q7QURsV04sR0FBSSxRQ2tXRTtBRGxXTixHQUFJLFFDa1dFO0FEaldOLEtBQU0sUUNpV0E7QURqV04sS0FBTSxRQ2lXQTtBRGhXTixVQUFXLFFDZ1dMO0FEaFdOLFVBQVcsUUNnV0w7QUQvVk4sRUFBRyxRQytWRztBRC9WTixFQUFHLFFDK1ZHO0FEOVZOLEdBQUksUUM4VkU7QUQ5Vk4sR0FBSSxRQzhWRTtBRDdWTixFQUFHLFFDNlZHO0FEN1ZOLEVBQUcsUUM2Vkc7QUQ1Vk4sR0FBSSxRQzRWRTtBRDVWTixHQUFJLFFDNFZFO0FEM1ZOLEVBQUcsUUMyVkc7QUQzVk4sRUFBRyxRQzJWRztBRDFWTixHQUFJLFFDMFZFO0FEMVZOLEdBQUksUUMwVkU7QUR6Vk4sRUFBRyxRQ3lWRztBRHpWTixFQUFHLFFDeVZHO0FEeFZOLEdBQUksUUN3VkU7QUR4Vk4sR0FBSSxRQ3dWRTtBRHZWTixFQUFHLFFDdVZHO0FEdlZOLEVBQUcsUUN1Vkc7QUR0Vk4sR0FBSSxRQ3NWRTtBRHRWTixHQUFJLFFDc1ZFO0VEclZGLHdCQUFBOztBQXhTSixPQUFRLE1DNm5CRjtBRDduQk4sT0FBUSxNQzZuQkY7RUQ1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FEREosT0FBUSxNQzZuQkY7QUQ3bkJOLE9BQVEsTUM2bkJGO0VENW5CRiw4QkFBQTs7QUNESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBQXFSSixDQUFFLFFBdVdJO0FBdldOLENBQUUsUUF1V0k7QUF0V04sRUFBRyxRQXNXRztBQXRXTixFQUFHLFFBc1dHO0FBcldOLEVBQUcsUUFxV0c7QUFyV04sRUFBRyxRQXFXRztBQXBXTixFQUFHLFFBb1dHO0FBcFdOLEVBQUcsUUFvV0c7QUFuV04sTUFBTyxRQW1XRDtBQW5XTixNQUFPLFFBbVdEO0FBbFdOLEdBQUksUUFrV0U7QUFsV04sR0FBSSxRQWtXRTtBQWpXTixLQUFNLFFBaVdBO0FBaldOLEtBQU0sUUFpV0E7QUFoV04sVUFBVyxRQWdXTDtBQWhXTixVQUFXLFFBZ1dMO0FBL1ZOLEVBQUcsUUErVkc7QUEvVk4sRUFBRyxRQStWRztBQTlWTixHQUFJLFFBOFZFO0FBOVZOLEdBQUksUUE4VkU7QUE3Vk4sRUFBRyxRQTZWRztBQTdWTixFQUFHLFFBNlZHO0FBNVZOLEdBQUksUUE0VkU7QUE1Vk4sR0FBSSxRQTRWRTtBQTNWTixFQUFHLFFBMlZHO0FBM1ZOLEVBQUcsUUEyVkc7QUExVk4sR0FBSSxRQTBWRTtBQTFWTixHQUFJLFFBMFZFO0FBelZOLEVBQUcsUUF5Vkc7QUF6Vk4sRUFBRyxRQXlWRztBQXhWTixHQUFJLFFBd1ZFO0FBeFZOLEdBQUksUUF3VkU7QUF2Vk4sRUFBRyxRQXVWRztBQXZWTixFQUFHLFFBdVZHO0FBdFZOLEdBQUksUUFzVkU7QUF0Vk4sR0FBSSxRQXNWRTtFQXJWRix3QkFBQTs7QUE0VlI7QUFDQSxLQUFNO0VBQ0YsZ0NBQUE7O0FBR0o7RUE1b0JJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQTRvQkEsZ0JBQUE7O0FEM29CQSxPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtFQUNKLDhCQUFBOztBQTZvQlIsS0FBTTtFQW5yQkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtDK3FCRSxHRC9xQkE7QUFDRixLQzhxQkUsR0Q5cUJBO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUNncUJOLEdEL3FCQTtBQWVGLE9BQVEsTUNncUJOLEdEOXFCQTtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTUFncUJOLEdEL3FCQTtBQ2VGLE9BQVEsTUFncUJOLEdEOXFCQTtFQ2VFLDZCQUFBOztBRFhKLEtDMHFCRSxHRDFxQkE7QUFDRixLQ3lxQkUsR0R6cUJBO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1DOG9CTixHRDFxQkE7QUE0QkYsT0FBUSxNQzhvQk4sR0R6cUJBO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE4b0JOLEdEMXFCQTtBQzRCRixPQUFRLE1BOG9CTixHRHpxQkE7RUM0QkUsOEJBQUE7O0FBbENKLEtBK3FCRSxHQS9xQkE7QUFDRixLQThxQkUsR0E5cUJBO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUNncUJOLEdBL3FCQTtBRGVGLE9BQVEsTUNncUJOLEdBOXFCQTtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsTUFncUJOLEdBL3FCQTtBQWVGLE9BQVEsTUFncUJOLEdBOXFCQTtFQWVFLDZCQUFBOztBQVhKLEtBMHFCRSxHQTFxQkE7QUFDRixLQXlxQkUsR0F6cUJBO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1DOG9CTixHQTFxQkE7QUQ0QkYsT0FBUSxNQzhvQk4sR0F6cUJBO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE4b0JOLEdBMXFCQTtBQTRCRixPQUFRLE1BOG9CTixHQXpxQkE7RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTJxQlI7RUFDSSxzQkFBQTtFQUNBLHFCQUFBOztBSHJyQkoscUJBSDBDO0VBRzFDO0lHd3JCUSxxQkFBQTtJQUNBLG9CQUFBOzs7QUZ6ckJSLHFCQUgwQztFQUcxQztJRXdyQlEscUJBQUE7SUFDQSxvQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTRCUjtFQUNJLGNBQUE7RUFFQSx1QkFBQTtFQXR2QkEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBQUU7QUFDRixLQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURmTjtBQ2VGLE9BQVEsTURkTjtFQ2VFLDZCQUFBOztBRFhKLEtBQUU7QUFDRixLQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDVCTjtBQzRCRixPQUFRLE1EM0JOO0VDNEJFLDhCQUFBOztBQWxDSixLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZk47QURlRixPQUFRLE1DZE47RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzVCTjtBRDRCRixPQUFRLE1DM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUE2c0JSLEtBTUksTUFBSztBQU5ULEtBT0ksTUFBSztFQUNELHFCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdUVSLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMO0FBQ0EsTUFBTTtFQUdGLHFCQUFBO0VBQ0EsU0FBQTtFQUNBLGdCQUFBO0VBQ0EsOEJBQUE7RUFDQSxjQUFBO0VBQ0EsbUJBQUE7RUFDQSx5QkFBQTtFQUNBLGdCQUFBO0VBQ0EsbUJBQUE7RUFDQSx3QkFBQTtFQUNBLDhDQUFBOztBQUtKO0VBQ0ksd0JBQUE7O0FBS0osS0FBSyxhQUFhO0FBQ2xCLEtBQUssYUFBYTtBQUNsQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssY0FBYztBQUNuQixLQUFLLGNBQWM7QUFDbkIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7QUFDcEIsUUFBUTtBQUNSLFFBQVE7QUFDUixNQUFNLFVBQVU7QUFDaEIsTUFBTSxVQUFVO0VBQ1oseUJBQUE7RUFDQSwwQkFBQTtFQUNBLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDRyxPQ2gwQjZCLGtCRGcwQjdCOztBQUVIO0VBQ0csT0NuMEI2QixrQkRtMEI3Qjs7QUFFSDtFQUNHLE9DdDBCNkIsa0JEczBCN0I7Ozs7Ozs7Ozs7Ozs7O0FBaUJIO0VBQ0ksZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNCSjtFQUNJLGNBQUE7RUFDQSxlQUFBOztBQUZKLE1BSUk7RUFFSSxzQkFBQTs7QUFJUixpQkFBa0I7RUFDZCx5QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FFbjVCSjtFQUNFLGFBQWEsZUFBYjtFQUNBLFNBQVMsd0JBQVQ7RUFDQSxTQUFTLGdDQUF1QyxPQUFPLDBCQUNqRCwwQkFBaUMsT0FBTyxhQUN4Qyx5QkFBZ0MsT0FBTyxpQkFDdkMseUJBQWdDLE9BQU8sTUFIN0M7RUFJQSxtQkFBQTtFQUNBLGtCQUFBOztBQWdCRjtBQUNBLENBQUM7RUFDQyxhQUFhLGVBQWI7RUFDQSxxQkFBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxjQUFBO0VBQ0EsbUNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb1FGLENBQUMsT0FBaUI7RUFDaEIsdUJBQUE7RUFDQSxtQkFBQTtFQUNBLG9CQUFBOztBQUdGLENBQUMsT0FBaUI7RUFBTyxjQUFBOztBQUN6QixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7QUFDekIsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7O0FBQ3pCLENBQUMsT0FBaUI7RUFBTyxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTZEekIsQ0FBQyxPQUFpQjtFQUNoQix5QkFBQTtFQUNBLDRCQUFBO0VBQ0EsbUJBQUE7O0FBR0YsQ0FBQyxPQUFpQjtFQXpDaEIsUUFBUSx3REFBUjtFQUNBLG1CQUFtQixhQUFuQjtFQUNJLGVBQWUsYUFBZjtFQUNJLFdBQVcsYUFBWDs7QUF1Q1YsQ0FBQyxPQUFpQjtFQTFDaEIsUUFBUSx3REFBUjtFQUNBLG1CQUFtQixjQUFuQjtFQUNJLGVBQWUsY0FBZjtFQUNJLFdBQVcsY0FBWDs7QUF3Q1YsQ0FBQyxPQUFpQjtFQTNDaEIsUUFBUSx3REFBUjtFQUNBLG1CQUFtQixjQUFuQjtFQUNJLGVBQWUsY0FBZjtFQUNJLFdBQVcsY0FBWDs7QUEwQ1YsQ0FBQyxPQUFpQjtFQXRDaEIsUUFBUSxrRUFBUjtFQUNBLG1CQUFtQixZQUFuQjtFQUNJLGVBQWUsWUFBZjtFQUNJLFdBQVcsWUFBWDs7QUFvQ1YsQ0FBQyxPQUFpQjtFQXZDaEIsUUFBUSxrRUFBUjtFQUNBLG1CQUFtQixZQUFuQjtFQUNJLGVBQWUsWUFBZjtFQUNJLFdBQVcsWUFBWDs7QUFzQ1YsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtFQUN0QixZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBc0JGLENBQUMsT0FBaUI7RUFDaEIsNkNBQUE7RUFDUSxxQ0FBQTs7QUFHVixDQUFDLE9BQWlCO0VBQ2hCLHVDQUF1QyxRQUF2QztFQUNRLCtCQUErQixRQUEvQjs7QUFHVjtFQUNFO0lBQ0UsbUJBQW1CLFlBQW5CO0lBQ1EsV0FBVyxZQUFYOztFQUVWO0lBQ0UsbUJBQW1CLGNBQW5CO0lBQ1EsV0FBVyxjQUFYOzs7QUFJWjtFQUNFO0lBQ0UsbUJBQW1CLFlBQW5CO0lBQ1EsV0FBVyxZQUFYOztFQUVWO0lBQ0UsbUJBQW1CLGNBQW5CO0lBQ1EsV0FBVyxjQUFYOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE4Q1IsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsZmQsNkVBQUE7O0FBd2ZBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdmZkLDZFQUFBOztBQTZmQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVmZCw2RUFBQTs7QUFrZ0JBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamdCZCw2RUFBQTs7QUF1Z0JBLENBREgsT0FBaUIsR0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdGdCZCw2RUFBQTs7QUE0Z0JBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM2dCZCw2RUFBQTs7QUFpaEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaGhCZCw2RUFBQTs7QUFzaEJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcmhCZCw2RUFBQTs7QUEyaEJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMWhCZCw2RUFBQTs7QUFnaUJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9oQmQsNkVBQUE7O0FBcWlCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBpQmQsNkVBQUE7O0FBMGlCQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6aUJkLDZFQUFBOztBQStpQkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5aUJkLDZFQUFBOztBQW9qQkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuakJkLDZFQUFBOztBQXlqQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4akJkLDZFQUFBOztBQThqQkEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN2pCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXdtQkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2bUJkLDZFQUFBOztBQTZtQkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1bUJkLDZFQUFBOztBQWtuQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqbkJkLDZFQUFBOztBQXVuQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0bkJkLDZFQUFBOztBQTRuQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzbkJkLDZFQUFBOztBQWlvQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFob0JkLDZFQUFBOztBQXNvQkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyb0JkLDZFQUFBOztBQTJvQkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExb0JkLDZFQUFBOztBQWdwQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvb0JkLDZFQUFBOztBQXFwQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwcEJkLDZFQUFBOztBQTBwQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6cEJkLDZFQUFBOztBQStwQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5cEJkLDZFQUFBOztBQW9xQkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucUJkLDZFQUFBOztBQXlxQkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cUJkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbXRCQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWx0QmQsNkVBQUE7O0FBd3RCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ0QmQsNkVBQUE7O0FBNnRCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTV0QmQsNkVBQUE7O0FBa3VCQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqdUJkLDZFQUFBOztBQXV1QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0dUJkLDZFQUFBOztBQTR1QkEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3VCZCw2RUFBQTs7QUFpdkJBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHZCZCw2RUFBQTs7QUFzdkJBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnZCZCw2RUFBQTs7QUEydkJBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXZCZCw2RUFBQTs7QUFnd0JBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3ZCZCw2RUFBQTs7QUFxd0JBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHdCZCw2RUFBQTs7QUEwd0JBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBendCZCw2RUFBQTs7QUErd0JBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXdCZCw2RUFBQTs7QUFveEJBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW54QmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTB6QkEsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6ekJkLDZFQUFBOztBQSt6QkEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5ekJkLDZFQUFBOztBQW8wQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuMEJkLDZFQUFBOztBQXkwQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4MEJkLDZFQUFBOztBQTgwQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3MEJkLDZFQUFBOztBQW0xQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsMUJkLDZFQUFBOztBQXcxQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2MUJkLDZFQUFBOztBQTYxQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1MUJkLDZFQUFBOztBQWsyQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqMkJkLDZFQUFBOztBQXUyQkEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdDJCZCw2RUFBQTs7QUE0MkJBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMzJCZCw2RUFBQTs7QUFpM0JBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaDNCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBKzZCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTk2QmQsNkVBQUE7O0FBbzdCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW43QmQsNkVBQUE7O0FBeTdCQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXg3QmQsNkVBQUE7O0FBODdCQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTc3QmQsNkVBQUE7O0FBbThCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWw4QmQsNkVBQUE7O0FBdzhCQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXY4QmQsNkVBQUE7O0FBNjhCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTU4QmQsNkVBQUE7O0FBazlCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWo5QmQsNkVBQUE7O0FBdTlCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXQ5QmQsNkVBQUE7O0FBNDlCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTM5QmQsNkVBQUE7O0FBaStCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgrQmQsNkVBQUE7O0FBcytCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXIrQmQsNkVBQUE7O0FBMitCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTErQmQsNkVBQUE7O0FBZy9CQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS8rQmQsNkVBQUE7O0FBcS9CQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXAvQmQsNkVBQUE7O0FBMC9CQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXovQmQsNkVBQUE7O0FBKy9CQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTkvQmQsNkVBQUE7O0FBb2dDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5nQ2QsNkVBQUE7O0FBeWdDQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhnQ2QsNkVBQUE7O0FBOGdDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdnQ2QsNkVBQUE7O0FBbWhDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxoQ2QsNkVBQUE7O0FBd2hDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2aENkLDZFQUFBOztBQTZoQ0EsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1aENkLDZFQUFBOztBQWtpQ0EsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqaUNkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWdvQ0EsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvbkNkLDZFQUFBOztBQXFvQ0EsQ0FESCxPQUFpQixtQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcG9DZCw2RUFBQTs7QUEwb0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBem9DZCw2RUFBQTs7QUErb0NBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlvQ2QsNkVBQUE7O0FBb3BDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5wQ2QsNkVBQUE7O0FBeXBDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhwQ2QsNkVBQUE7O0FBOHBDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdwQ2QsNkVBQUE7O0FBbXFDQSxDQURILE9BQWlCLHFCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFscUNkLDZFQUFBOztBQXdxQ0EsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2cUNkLDZFQUFBOztBQTZxQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1cUNkLDZFQUFBOztBQWtyQ0EsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanJDZCw2RUFBQTs7QUF1ckNBLENBREgsT0FBaUIsc0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRyQ2QsNkVBQUE7O0FBNHJDQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNyQ2QsNkVBQUE7O0FBaXNDQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoc0NkLDZFQUFBOztBQXNzQ0EsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyc0NkLDZFQUFBOztBQTJzQ0EsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExc0NkLDZFQUFBOztBQWd0Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvc0NkLDZFQUFBOztBQXF0Q0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHRDZCw2RUFBQTs7QUEwdENBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenRDZCw2RUFBQTs7QUErdENBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXRDZCw2RUFBQTs7QUFvdUNBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnVDZCw2RUFBQTs7QUF5dUNBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXh1Q2QsNkVBQUE7O0FBOHVDQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3dUNkLDZFQUFBOztBQW12Q0EsQ0FESCxPQUFpQiwwQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHZDZCw2RUFBQTs7QUF3dkNBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnZDZCw2RUFBQTs7QUE2dkNBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTV2Q2QsNkVBQUE7O0FBa3dDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWp3Q2QsNkVBQUE7O0FBdXdDQSxDQURILE9BQWlCLHFCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0d0NkLDZFQUFBOztBQTR3Q0EsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzd0NkLDZFQUFBOztBQWl4Q0EsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHhDZCw2RUFBQTs7QUFzeENBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnhDZCw2RUFBQTs7QUEyeENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXhDZCw2RUFBQTs7QUFneUNBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS94Q2QsNkVBQUE7O0FBcXlDQSxDQURILE9BQWlCLHNCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFweUNkLDZFQUFBOztBQTB5Q0EsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6eUNkLDZFQUFBOztBQSt5Q0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXlDZCw2RUFBQTs7QUFvekNBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnpDZCw2RUFBQTs7QUF5ekNBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXh6Q2QsNkVBQUE7O0FBOHpDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTd6Q2QsNkVBQUE7O0FBbTBDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsMENkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFpK0NBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaCtDZCw2RUFBQTs7QUFzK0NBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcitDZCw2RUFBQTs7QUEyK0NBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMStDZCw2RUFBQTs7QUFnL0NBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBLytDZCw2RUFBQTs7QUFxL0NBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcC9DZCw2RUFBQTs7QUEwL0NBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBei9DZCw2RUFBQTs7QUErL0NBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOS9DZCw2RUFBQTs7QUFvZ0RBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmdEZCw2RUFBQTs7QUF5Z0RBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGdEZCw2RUFBQTs7QUE4Z0RBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN2dEZCw2RUFBQTs7QUFtaERBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbGhEZCw2RUFBQTs7QUF3aERBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZoRGQsNkVBQUE7O0FBNmhEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVoRGQsNkVBQUE7O0FBa2lEQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqaURkLDZFQUFBOztBQXVpREEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0aURkLDZFQUFBOztBQTRpREEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM2lEZCw2RUFBQTs7QUFpakRBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaGpEZCw2RUFBQTs7QUFzakRBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJqRGQsNkVBQUE7O0FBMmpEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFqRGQsNkVBQUE7O0FBZ2tEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvakRkLDZFQUFBOztBQXFrREEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwa0RkLDZFQUFBOztBQTBrREEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6a0RkLDZFQUFBOztBQStrREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5a0RkLDZFQUFBOztBQW9sREEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmxEZCw2RUFBQTs7QUF5bERBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGxEZCw2RUFBQTs7QUE4bERBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN2xEZCw2RUFBQTs7QUFtbURBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbG1EZCw2RUFBQTs7QUF3bURBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZtRGQsNkVBQUE7O0FBNm1EQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVtRGQsNkVBQUE7O0FBa25EQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpuRGQsNkVBQUE7O0FBdW5EQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRuRGQsNkVBQUE7O0FBNG5EQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNuRGQsNkVBQUE7O0FBaW9EQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhvRGQsNkVBQUE7O0FBc29EQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJvRGQsNkVBQUE7O0FBMm9EQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFvRGQsNkVBQUE7O0FBZ3BEQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9vRGQsNkVBQUE7O0FBcXBEQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBwRGQsNkVBQUE7O0FBMHBEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXpwRGQsNkVBQUE7O0FBK3BEQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlwRGQsNkVBQUE7O0FBb3FEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5xRGQsNkVBQUE7O0FBeXFEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhxRGQsNkVBQUE7O0FBOHFEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdxRGQsNkVBQUE7O0FBbXJEQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxyRGQsNkVBQUE7O0FBd3JEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZyRGQsNkVBQUE7O0FBNnJEQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1ckRkLDZFQUFBOztBQWtzREEsQ0FESCxPQUFpQix3QkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanNEZCw2RUFBQTs7QUF1c0RBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHNEZCw2RUFBQTs7QUE0c0RBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNzRGQsNkVBQUE7O0FBaXREQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh0RGQsNkVBQUE7O0FBc3REQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFydERkLDZFQUFBOztBQTJ0REEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExdERkLDZFQUFBOztBQWd1REEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvdERkLDZFQUFBOztBQXF1REEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwdURkLDZFQUFBOztBQTB1REEsQ0FESCxPQUFpQixtQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenVEZCw2RUFBQTs7QUErdURBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXVEZCw2RUFBQTs7QUFvdkRBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW52RGQsNkVBQUE7O0FBeXZEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXh2RGQsNkVBQUE7O0FBOHZEQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3dkRkLDZFQUFBOztBQW13REEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsd0RkLDZFQUFBOztBQXd3REEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdndEZCw2RUFBQTs7QUE2d0RBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXdEZCw2RUFBQTs7QUFreERBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanhEZCw2RUFBQTs7QUF1eERBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHhEZCw2RUFBQTs7QUE0eERBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3hEZCw2RUFBQTs7QUFpeURBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHlEZCw2RUFBQTs7QUFzeURBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ5RGQsNkVBQUE7O0FBMnlEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF5RGQsNkVBQUE7O0FBZ3pEQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEveURkLDZFQUFBOztBQXF6REEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwekRkLDZFQUFBOztBQTB6REEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6ekRkLDZFQUFBOztBQSt6REEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5ekRkLDZFQUFBOztBQW8wREEsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbjBEZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDeUxKO0VBQ0ksc0JBQUE7O0FBR0o7RUFDSSxVQUFBO0VBQ0EsU0FBQTtFQUNBLDZCQUFBO0VBQ0EsZUFBQTs7QUFFQSxrQkFBQztFQUNHLDJCQUFBO0VBQ0EsbUJBQUE7O0FSMUxKLG1CQUFDO0VBQ0csU0FBUyxFQUFUO0VBQ0EsY0FBQTtFQUNBLFdBQUE7O0FBRUosT0FBUTtFQUNKLE9BQUE7O0FDTkosbUJBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QU8yTlI7RUFDSSxjQUFBO0VIMU5BLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTs7QURDQSxPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtFQUNKLDhCQUFBOztBRzBOUjtFQUNJLGNBQUE7RUh4UEEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VHd1BBLGtCQUFBO0VBQ0EsdUJBQUE7O0FKdlBBLGdCQUFFO0FBQ0YsZ0JBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxpQkFmTjtBQWVGLE9BQVEsaUJBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGlCRGZOO0FDZUYsT0FBUSxpQkRkTjtFQ2VFLDZCQUFBOztBRFhKLGdCQUFFO0FBQ0YsZ0JBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsaUJBNUJOO0FBNEJGLE9BQVEsaUJBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsaUJENUJOO0FDNEJGLE9BQVEsaUJEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixnQkFBRTtBQUNGLGdCQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsaUJDZk47QURlRixPQUFRLGlCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxpQkFmTjtBQWVGLE9BQVEsaUJBZE47RUFlRSw2QkFBQTs7QUFYSixnQkFBRTtBQUNGLGdCQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGlCQzVCTjtBRDRCRixPQUFRLGlCQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGlCQTVCTjtBQTRCRixPQUFRLGlCQTNCTjtFQTRCRSw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUc2UVI7QUFDQTtFQUNJLDJCQUFBOztBQUdKO0VBQ0ksV0FBVyxjQUFYOztBQUdKLHFCQUFzQjtFQUNsQixXQUFXLFNBQVg7O0FBR0oscUJBQXNCO0VBQ2xCLFdBQVcsZUFBWDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErQ0o7RUFDSSxjQUFBOztBUmhXQSxrQkFBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGNBQUE7RUFDQSxXQUFBOztBQUVKLE9BQVE7RUFDSixPQUFBOztBQ05KLGtCQUFDO0VBQ0csU0FBUyxFQUFUO0VBQ0EsY0FBQTtFQUNBLFdBQUE7O0FBRUosT0FBUTtFQUNKLE9BQUE7O0FPK1ZKLE1BQU07RUFDRixXQUFBO0VBQ0EsZ0JBQUE7O0FBSVI7RUFDSSx3QkFBQTs7QUFHSjtFQUNJLFdBQUE7O0FBR0o7RUFDSSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFxQko7RUFDSSxzQkFBQTtFQUNBLG1CQUFBOztBQUVBLG1CQUFDO0FBQ0QsbUJBQUM7RUFDRyxtQkFBQTs7QUFOUixtQkFTSTtFQUNJLG9CQUFBOztBQVZSLG1CQWNJO0VBRUkscUJBQUE7O0FBS0EsbUJBUEosb0JBT0s7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdU1aO0VBQ0ksc0JBQUE7O0FBR0o7RUFDSSxrQ0FBQTtFQUVBLGdDQUFBO0VBQ0EsbUJBQUE7RUFDQSxjQUFBO0VIbG1CQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUF1R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsaUJBQUE7RUFDQSx5QkFBQTtFR3VmQSxnQkFBQTs7QUpqbUJBLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0VBQ0osOEJBQUE7O0FEREosT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7RUFDSiw4QkFBQTs7QUdtbUJSLGlCQUFrQjtFQUNkLGdDQUFBO0VBQ0EsZ0JBQUE7RUFDQSxtQkFBQTs7QUFHSixpQkFBa0I7RUh0bkJkLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUc2Z0JBLGdCQUFBOztBSnJuQkEsT0FBUSxrQkltbkJNO0VKbG5CViw4QkFBQTs7QUNESixPQUFRLGtCR21uQk07RUhsbkJWLDhCQUFBOztBRERKLE9BQVEsa0JJbW5CTTtFSmxuQlYsOEJBQUE7O0FDREosT0FBUSxrQkdtbkJNO0VIbG5CViw4QkFBQTs7QUd1bkJSLGlCQUFrQjtFQUNkLGdCQUFBIn0= */

--- a/src/cf-expandables.less
+++ b/src/cf-expandables.less
@@ -686,7 +686,7 @@
     border-bottom: 1px solid @expandable-group-divider;
     background: @expandable-group_header-bg;
     color: @expandable-group_header-text;
-    .h5();
+    .heading-5();
     margin-bottom: 0;
 }
 
@@ -697,7 +697,7 @@
 }
 
 .expandable-group .expandable_label {
-    .h4();
+    .heading-4();
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
Updated for the new heading changes in cf-core
## Additions
- None
## Removals
- None
## Changes
- Changed `.h#()` mixins to `.heading-#()` to avoid over-writing top-margin
- Removed visually tweaked margins
## Review
- @Scotchester 
- @KimberlyMunoz 
- @cfarm 
- @ascott1 
## Notes
- .h# mixins should no longer be used if default margin mixes aren't required, use .heading-# instead
- We're no longer tweaking margins by eye, use the default margin for headings unless necessary, such as the header-slug
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
